### PR TITLE
Fix toast listener effect deps

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- update `useEffect` dependency in `use-toast` so listener is only registered once

## Testing
- `npm run lint` *(fails: no-case-declarations, unused vars, etc.)*
- `npm run build` *(fails: TS6133 'React' is declared but its value is never read)*

------
https://chatgpt.com/codex/tasks/task_e_686d608ace1c8325a7fe914524d0e3f2