### PR TITLE
Update toast remove delay

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -6,7 +6,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- tweak toast constants to use a 5‑second remove delay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d8e57b3ac8325800a005c8f183dd2