### PR TITLE
Fix import error handling

### DIFF
--- a/src/components/dns/dns-manager.tsx
+++ b/src/components/dns/dns-manager.tsx
@@ -228,10 +228,10 @@ export function DNSManager({ apiKey, onLogout }: DNSManagerProps) {
         title: "Success",
         description: "Records imported successfully"
       });
-    } catch {
+    } catch (error) {
       toast({
         title: "Error",
-        description: "Failed to import records: Invalid JSON format",
+        description: "Failed to import records: " + (error as Error).message,
         variant: "destructive"
       });
     }


### PR DESCRIPTION
## Summary
- handle import errors by adding error param to catch block

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e5bdfb3bc8325a69521c2961d19c0