### PR TITLE
Fix request fallback error message

### DIFF
--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -20,7 +20,7 @@ export class CloudflareAPI {
     });
 
     if (!response.ok) {
-      const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+      const error = await response.json().catch(() => ({ errors: [{ message: 'Unknown error' }] }));
       throw new Error(error.errors?.[0]?.message || `HTTP ${response.status}: ${response.statusText}`);
     }
 


### PR DESCRIPTION
## Summary
- handle JSON parse failures by returning an `errors` array

## Testing
- `npm run lint`
- `npm run build`
- `npx tsx test-unknown-error.ts` *(shows `Unknown error`)*

------
https://chatgpt.com/codex/tasks/task_e_686ee3b701fc8325bdcea91ba30d5ea7