### PR TITLE
Persist encryption settings

### DIFF
--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -29,6 +29,11 @@ export function LoginForm({ onLogin }: LoginFormProps) {
   
   const { toast } = useToast();
   const apiKeys = storageManager.getApiKeys();
+
+  useEffect(() => {
+    cryptoManager.reloadConfig();
+    setEncryptionSettings(cryptoManager.getConfig());
+  }, []);
 
   const handleLogin = async () => {
     if (!selectedKeyId || !password) {


### PR DESCRIPTION
## Summary
- add `CONFIG_STORAGE_KEY` constant and persist settings in `CryptoManager`
- reload encryption settings from storage in `LoginForm`

## Testing
- `npm run lint`
- `npm run build` *(fails: Block-scoped variable 'loadZones' used before its declaration)*

------
https://chatgpt.com/codex/tasks/task_e_686eefdaafcc8325b7df5ee4c325eda6