### PR TITLE
Add AbortController support for API requests

### DIFF
--- a/src/components/dns/dns-manager.tsx
+++ b/src/components/dns/dns-manager.tsx
@@ -40,19 +40,23 @@ export function DNSManager({ apiKey, onLogout }: DNSManagerProps) {
   const api = new CloudflareAPI(apiKey);
 
   useEffect(() => {
-    loadZones();
+    const controller = new AbortController();
+    loadZones(controller.signal);
+    return () => controller.abort();
   }, [loadZones]);
 
   useEffect(() => {
     if (selectedZone) {
-      loadRecords();
+      const controller = new AbortController();
+      loadRecords(controller.signal);
+      return () => controller.abort();
     }
   }, [selectedZone, loadRecords]);
 
-  const loadZones = useCallback(async () => {
+  const loadZones = useCallback(async (signal?: AbortSignal) => {
     try {
       setIsLoading(true);
-      const zonesData = await api.getZones();
+      const zonesData = await api.getZones(signal);
       setZones(zonesData);
     } catch (error) {
       toast({
@@ -65,12 +69,12 @@ export function DNSManager({ apiKey, onLogout }: DNSManagerProps) {
     }
   }, [api, toast]);
 
-  const loadRecords = useCallback(async () => {
+  const loadRecords = useCallback(async (signal?: AbortSignal) => {
     if (!selectedZone) return;
-    
+
     try {
       setIsLoading(true);
-      const recordsData = await api.getDNSRecords(selectedZone);
+      const recordsData = await api.getDNSRecords(selectedZone, signal);
       setRecords(recordsData);
     } catch (error) {
       toast({

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -10,8 +10,10 @@ export class CloudflareAPI {
   }
 
   private async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+    const { signal, ...rest } = options;
     const response = await fetch(`${CLOUDFLARE_API_BASE}${endpoint}`, {
-      ...options,
+      ...rest,
+      signal,
       headers: {
         'Authorization': `Bearer ${this.apiKey}`,
         'Content-Type': 'application/json',
@@ -32,37 +34,40 @@ export class CloudflareAPI {
     return data.result as T;
   }
 
-  async getZones(): Promise<Zone[]> {
-    return this.request<Zone[]>('/zones');
+  async getZones(signal?: AbortSignal): Promise<Zone[]> {
+    return this.request<Zone[]>('/zones', { signal });
   }
 
-  async getDNSRecords(zoneId: string): Promise<DNSRecord[]> {
-    return this.request<DNSRecord[]>(`/zones/${zoneId}/dns_records`);
+  async getDNSRecords(zoneId: string, signal?: AbortSignal): Promise<DNSRecord[]> {
+    return this.request<DNSRecord[]>(`/zones/${zoneId}/dns_records`, { signal });
   }
 
-  async createDNSRecord(zoneId: string, record: Partial<DNSRecord>): Promise<DNSRecord> {
+  async createDNSRecord(zoneId: string, record: Partial<DNSRecord>, signal?: AbortSignal): Promise<DNSRecord> {
     return this.request<DNSRecord>(`/zones/${zoneId}/dns_records`, {
       method: 'POST',
       body: JSON.stringify(record),
+      signal,
     });
   }
 
-  async updateDNSRecord(zoneId: string, recordId: string, record: Partial<DNSRecord>): Promise<DNSRecord> {
+  async updateDNSRecord(zoneId: string, recordId: string, record: Partial<DNSRecord>, signal?: AbortSignal): Promise<DNSRecord> {
     return this.request<DNSRecord>(`/zones/${zoneId}/dns_records/${recordId}`, {
       method: 'PUT',
       body: JSON.stringify(record),
+      signal,
     });
   }
 
-  async deleteDNSRecord(zoneId: string, recordId: string): Promise<void> {
+  async deleteDNSRecord(zoneId: string, recordId: string, signal?: AbortSignal): Promise<void> {
     await this.request<void>(`/zones/${zoneId}/dns_records/${recordId}`, {
       method: 'DELETE',
+      signal,
     });
   }
 
-  async verifyToken(): Promise<boolean> {
+  async verifyToken(signal?: AbortSignal): Promise<boolean> {
     try {
-      await this.request<void>('/user/tokens/verify');
+      await this.request<void>('/user/tokens/verify', { signal });
       return true;
     } catch {
       return false;


### PR DESCRIPTION
## Summary
- add abort `signal` to CloudflareAPI requests
- support request cancellation in DNS manager loaders
- abort fetches on component unmount

## Testing
- `npm run lint`
- `npm run build` *(fails: Block-scoped variable 'loadZones' used before its declaration)*

------
https://chatgpt.com/codex/tasks/task_e_686eefd73a588325850f4d4e70d6b2d2