### PR TITLE
Add configurable base URL for Cloudflare API

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,11 @@
 /// <reference types="vite/client" />
 
 declare module '*.css';
+
+interface ImportMetaEnv {
+  readonly VITE_CLOUDFLARE_API_BASE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- allow `CloudflareAPI` base URL to be overridden via env or constructor
- handle error responses without an `errors` array
- expose `VITE_CLOUDFLARE_API_BASE` type in `vite-env.d.ts`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f070e036883259ce420bf5462ef95