### PR TITLE
Add UUID helper

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,5 +1,6 @@
 import type { ApiKey } from '@/types/dns';
 import { cryptoManager, CryptoManager } from './crypto';
+import { generateUUID } from './utils';
 
 const STORAGE_KEY = 'cloudflare-dns-manager';
 
@@ -42,7 +43,7 @@ export class StorageManager {
     const config = cryptoManager.getConfig();
 
     const keyData: ApiKey = {
-      id: crypto.randomUUID(),
+      id: generateUUID(),
       label,
       encryptedKey: encrypted,
       salt,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,17 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function generateUUID(): string {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  const bytes = crypto.getRandomValues(new Uint8Array(16))
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0'))
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex
+    .slice(6, 8)
+    .join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10).join('')}`
+}


### PR DESCRIPTION
## Summary
- add `generateUUID` helper that falls back to a v4 polyfill when `crypto.randomUUID` is unavailable
- use the new helper in `StorageManager.addApiKey`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f12bb469c832589969b1f37250e1f