### PR TITLE
Adjust priority resetting on record type change

### DIFF
--- a/src/components/dns/dns-manager.tsx
+++ b/src/components/dns/dns-manager.tsx
@@ -335,10 +335,14 @@ export function DNSManager({ apiKey, onLogout }: DNSManagerProps) {
                             <Label>Type</Label>
                             <Select
                               value={newRecord.type}
-                              onValueChange={(value: string) => setNewRecord({
-                                ...newRecord,
-                                type: value as RecordType
-                              })}
+                              onValueChange={(value: string) =>
+                                setNewRecord(prev => ({
+                                  ...prev,
+                                  type: value as RecordType,
+                                  priority:
+                                    value === 'MX' ? prev.priority : undefined
+                                }))
+                              }
                             >
                               <SelectTrigger>
                                 <SelectValue />


### PR DESCRIPTION
## Summary
- reset `priority` when new DNS record type changes away from MX

## Testing
- `npm run lint` *(fails: 'error  Unexpected any. Specify a different type')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f2509ed1883259e16cca3646005db