### PR TITLE
Format cn function

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,8 +1,12 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+export function cn(
+  ...inputs: ClassValue[]
+) {
+  return twMerge(
+    clsx(inputs)
+  );
 }
 
 export function generateUUID(): string {


### PR DESCRIPTION
## Summary
- multi-line formatting for cn function
- add semicolon to cn return

## Testing
- `npm run lint` *(fails: no-unused-vars, no-explicit-any)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f2512f2c08325805ecb219b12bc8a