### PR TITLE
Document custom API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ npm run dev
 
 Then open <http://localhost:5173> in your browser.
 
+### Custom API base
+
+By default the app talks to the real Cloudflare API at
+`https://api.cloudflare.com/client/v4`. You can change this URL using the
+`VITE_CLOUDFLARE_API_BASE` environment variable, which is useful when working
+with a mock API during development.
+
+Create a `.env` file with your desired base URL:
+
+```bash
+# .env
+VITE_CLOUDFLARE_API_BASE=http://localhost:8787
+```
+
+Run the app with the custom base applied:
+
+```bash
+VITE_CLOUDFLARE_API_BASE=http://localhost:8787 npm run dev
+```
+
 ## Building for production
 
 Create an optimized build and preview it locally:


### PR DESCRIPTION
## Summary
- document `VITE_CLOUDFLARE_API_BASE` in the Development section
- show an example `.env` and command for using a custom API base

## Testing
- `npm test`
- `npm run lint` *(fails: react-hooks/exhaustive-deps & typescript-eslint)*

------
https://chatgpt.com/codex/tasks/task_e_686feee85c8c8325a8ec6d0e4160804a