### PR TITLE
Add type guard for storage import validation

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -9,6 +9,31 @@ interface StorageData {
   currentSession?: string;
 }
 
+export function isStorageData(value: unknown): value is StorageData {
+  if (!value || typeof value !== 'object') return false;
+  const obj = value as any;
+  if (!Array.isArray(obj.apiKeys)) return false;
+  if (
+    obj.currentSession !== undefined &&
+    typeof obj.currentSession !== 'string'
+  ) {
+    return false;
+  }
+  return obj.apiKeys.every(
+    (k: any) =>
+      k &&
+      typeof k.id === 'string' &&
+      typeof k.label === 'string' &&
+      typeof k.encryptedKey === 'string' &&
+      typeof k.salt === 'string' &&
+      typeof k.iv === 'string' &&
+      typeof k.iterations === 'number' &&
+      typeof k.keyLength === 'number' &&
+      typeof k.algorithm === 'string' &&
+      typeof k.createdAt === 'string'
+  );
+}
+
 export class StorageManager {
   private data: StorageData = { apiKeys: [] };
 
@@ -119,19 +144,7 @@ export class StorageManager {
       throw new Error('Failed to import data: Invalid JSON');
     }
 
-    if (
-      !imported ||
-      typeof imported !== 'object' ||
-      !Array.isArray((imported as any).apiKeys) ||
-      !(imported as any).apiKeys.every((k: any) =>
-        k &&
-        typeof k.id === 'string' &&
-        typeof k.label === 'string' &&
-        typeof k.encryptedKey === 'string' &&
-        typeof k.salt === 'string' &&
-        typeof k.iv === 'string'
-      )
-    ) {
+    if (!isStorageData(imported)) {
       throw new Error('Invalid data format');
     }
 

--- a/test/storageManager.test.ts
+++ b/test/storageManager.test.ts
@@ -23,7 +23,7 @@ function resetStorage() {
 
 test('importData accepts valid data', async () => {
   resetStorage();
-  const { StorageManager } = await import('../src/lib/storage.ts');
+  const { StorageManager, isStorageData } = await import('../src/lib/storage.ts');
   const mgr = new StorageManager();
   const sample = {
     apiKeys: [
@@ -41,6 +41,7 @@ test('importData accepts valid data', async () => {
     ],
     currentSession: '1',
   };
+  assert.equal(isStorageData(sample), true);
   mgr.importData(JSON.stringify(sample));
   assert.equal(mgr.getApiKeys().length, 1);
   assert.equal(mgr.getCurrentSession(), '1');
@@ -48,9 +49,10 @@ test('importData accepts valid data', async () => {
 
 test('importData throws on invalid data without modifying existing state', async () => {
   resetStorage();
-  const { StorageManager } = await import('../src/lib/storage.ts');
+  const { StorageManager, isStorageData } = await import('../src/lib/storage.ts');
   const mgr = new StorageManager();
   const bad = { apiKeys: [{ id: '1', label: 'x' }] };
+  assert.equal(isStorageData(bad), false);
   assert.throws(() => mgr.importData(JSON.stringify(bad)), /Invalid data format/);
   assert.equal(mgr.getApiKeys().length, 0);
   assert.equal(mgr.getCurrentSession(), undefined);


### PR DESCRIPTION
## Summary
- validate imported storage objects with a new `isStorageData` type guard
- use the guard in `StorageManager.importData`
- test valid and invalid storage data via the guard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fef685a2c8325b7f30ba912046781