### PR TITLE
Refactor dialogs into components

### DIFF
--- a/src/components/auth/AddKeyDialog.tsx
+++ b/src/components/auth/AddKeyDialog.tsx
@@ -1,0 +1,73 @@
+import { ChangeEvent } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Plus } from 'lucide-react';
+
+export interface AddKeyDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  label: string;
+  onLabelChange: (val: string) => void;
+  apiKey: string;
+  onApiKeyChange: (val: string) => void;
+  password: string;
+  onPasswordChange: (val: string) => void;
+  onAdd: () => void;
+}
+
+export function AddKeyDialog({ open, onOpenChange, label, onLabelChange, apiKey, onApiKeyChange, password, onPasswordChange, onAdd }: AddKeyDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" className="flex-1">
+          <Plus className="h-4 w-4 mr-2" />
+          Add Key
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add New API Key</DialogTitle>
+          <DialogDescription>
+            Add a new Cloudflare API key with a custom label
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="new-label">Label</Label>
+            <Input
+              id="new-label"
+              value={label}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => onLabelChange(e.target.value)}
+              placeholder="e.g., Personal Account"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-api-key">API Key</Label>
+            <Input
+              id="new-api-key"
+              type="password"
+              value={apiKey}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => onApiKeyChange(e.target.value)}
+              placeholder="Your Cloudflare API key"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-password">Encryption Password</Label>
+            <Input
+              id="new-password"
+              type="password"
+              value={password}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => onPasswordChange(e.target.value)}
+              placeholder="Password to encrypt this key"
+            />
+          </div>
+          <Button onClick={onAdd} className="w-full">
+            Add API Key
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/auth/EncryptionSettingsDialog.tsx
+++ b/src/components/auth/EncryptionSettingsDialog.tsx
@@ -1,0 +1,82 @@
+import { ChangeEvent } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import type { EncryptionConfig } from '@/types/dns';
+import { Settings } from 'lucide-react';
+
+export interface EncryptionSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  settings: EncryptionConfig;
+  onSettingsChange: (settings: EncryptionConfig) => void;
+  onBenchmark: () => void;
+  onUpdate: () => void;
+  benchmarkResult: number | null;
+}
+
+export function EncryptionSettingsDialog({ open, onOpenChange, settings, onSettingsChange, onBenchmark, onUpdate, benchmarkResult }: EncryptionSettingsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="icon">
+          <Settings className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Encryption Settings</DialogTitle>
+          <DialogDescription>
+            Configure encryption parameters for security and performance
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="iterations">PBKDF2 Iterations</Label>
+            <Input
+              id="iterations"
+              type="number"
+              value={settings.iterations}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                onSettingsChange({ ...settings, iterations: parseInt(e.target.value) || 100000 })
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="key-length">Key Length (bits)</Label>
+            <Select
+              value={settings.keyLength.toString()}
+              onValueChange={(value) =>
+                onSettingsChange({ ...settings, keyLength: parseInt(value) })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="128">128</SelectItem>
+                <SelectItem value="192">192</SelectItem>
+                <SelectItem value="256">256</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex gap-2">
+            <Button onClick={onBenchmark} variant="outline" className="flex-1">
+              Benchmark
+            </Button>
+            <Button onClick={onUpdate} className="flex-1">
+              Update
+            </Button>
+          </div>
+          {benchmarkResult && (
+            <p className="text-sm text-muted-foreground">
+              Last benchmark: {benchmarkResult.toFixed(2)}ms
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -4,12 +4,14 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+
 import { storageManager } from '@/lib/storage';
 import { useCloudflareAPI } from '@/hooks/use-cloudflare-api';
 import { useToast } from '@/hooks/use-toast';
-import { Key, Plus, Settings, Trash2 } from 'lucide-react';
+import { Key, Trash2 } from 'lucide-react';
 import { cryptoManager } from '@/lib/crypto';
+import { AddKeyDialog } from './AddKeyDialog';
+import { EncryptionSettingsDialog } from './EncryptionSettingsDialog';
 
 interface LoginFormProps {
   onLogin: (apiKey: string) => void;
@@ -232,118 +234,27 @@ export function LoginForm({ onLogin }: LoginFormProps) {
           </Button>
 
           <div className="flex gap-2">
-            <Dialog open={showAddKey} onOpenChange={setShowAddKey}>
-              <DialogTrigger asChild>
-                <Button variant="outline" className="flex-1">
-                  <Plus className="h-4 w-4 mr-2" />
-                  Add Key
-                </Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Add New API Key</DialogTitle>
-                  <DialogDescription>
-                    Add a new Cloudflare API key with a custom label
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="new-label">Label</Label>
-                    <Input
-                      id="new-label"
-                      value={newKeyLabel}
-                      onChange={(e) => setNewKeyLabel(e.target.value)}
-                      placeholder="e.g., Personal Account"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="new-api-key">API Key</Label>
-                    <Input
-                      id="new-api-key"
-                      type="password"
-                      value={newApiKey}
-                      onChange={(e) => setNewApiKey(e.target.value)}
-                      placeholder="Your Cloudflare API key"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="new-password">Encryption Password</Label>
-                    <Input
-                      id="new-password"
-                      type="password"
-                      value={newPassword}
-                      onChange={(e) => setNewPassword(e.target.value)}
-                      placeholder="Password to encrypt this key"
-                    />
-                  </div>
-                  <Button onClick={handleAddKey} className="w-full">
-                    Add API Key
-                  </Button>
-                </div>
-              </DialogContent>
-            </Dialog>
+            <AddKeyDialog
+              open={showAddKey}
+              onOpenChange={setShowAddKey}
+              label={newKeyLabel}
+              onLabelChange={setNewKeyLabel}
+              apiKey={newApiKey}
+              onApiKeyChange={setNewApiKey}
+              password={newPassword}
+              onPasswordChange={setNewPassword}
+              onAdd={handleAddKey}
+            />
 
-            <Dialog open={showSettings} onOpenChange={setShowSettings}>
-              <DialogTrigger asChild>
-                <Button variant="outline" size="icon">
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Encryption Settings</DialogTitle>
-                  <DialogDescription>
-                    Configure encryption parameters for security and performance
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="iterations">PBKDF2 Iterations</Label>
-                    <Input
-                      id="iterations"
-                      type="number"
-                      value={encryptionSettings.iterations}
-                      onChange={(e) => setEncryptionSettings({
-                        ...encryptionSettings,
-                        iterations: parseInt(e.target.value) || 100000
-                      })}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="key-length">Key Length (bits)</Label>
-                    <Select
-                      value={encryptionSettings.keyLength.toString()}
-                      onValueChange={(value) => setEncryptionSettings({
-                        ...encryptionSettings,
-                        keyLength: parseInt(value)
-                      })}
-                    >
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="128">128</SelectItem>
-                        <SelectItem value="192">192</SelectItem>
-                        <SelectItem value="256">256</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="flex gap-2">
-                    <Button onClick={handleBenchmark} variant="outline" className="flex-1">
-                      Benchmark
-                    </Button>
-                    <Button onClick={handleUpdateSettings} className="flex-1">
-                      Update
-                    </Button>
-                  </div>
-                  {benchmarkResult && (
-                    <p className="text-sm text-muted-foreground">
-                      Last benchmark: {benchmarkResult.toFixed(2)}ms
-                    </p>
-                  )}
-                </div>
-              </DialogContent>
-            </Dialog>
+            <EncryptionSettingsDialog
+              open={showSettings}
+              onOpenChange={setShowSettings}
+              settings={encryptionSettings}
+              onSettingsChange={setEncryptionSettings}
+              onBenchmark={handleBenchmark}
+              onUpdate={handleUpdateSettings}
+              benchmarkResult={benchmarkResult}
+            />
           </div>
         </CardContent>
       </Card>

--- a/src/components/dns/AddRecordDialog.tsx
+++ b/src/components/dns/AddRecordDialog.tsx
@@ -1,0 +1,133 @@
+import { ChangeEvent } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import type { DNSRecord, RecordType } from '@/types/dns';
+import { Plus } from 'lucide-react';
+
+export interface AddRecordDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  record: Partial<DNSRecord>;
+  onRecordChange: (record: Partial<DNSRecord>) => void;
+  onAdd: () => void;
+  zoneName?: string;
+}
+
+export function AddRecordDialog({ open, onOpenChange, record, onRecordChange, onAdd, zoneName }: AddRecordDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Record
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add DNS Record</DialogTitle>
+          <DialogDescription>
+            Create a new DNS record for {zoneName}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>Type</Label>
+              <Select
+                value={record.type}
+                onValueChange={(value: string) =>
+                  onRecordChange({
+                    ...record,
+                    type: value as RecordType,
+                    priority: value === 'MX' ? record.priority : undefined
+                  })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(['A','AAAA','CNAME','MX','TXT','SRV','NS','PTR','CAA'] as RecordType[]).map(type => (
+                    <SelectItem key={type} value={type}>
+                      {type}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>TTL</Label>
+              <Input
+                type="number"
+                value={record.ttl}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  onRecordChange({
+                    ...record,
+                    ttl: parseInt(e.target.value) || 300
+                  })
+                }
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Name</Label>
+            <Input
+              value={record.name}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => onRecordChange({
+                ...record,
+                name: e.target.value
+              })}
+              placeholder="e.g., www or @ for root"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Content</Label>
+            <Input
+              value={record.content}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => onRecordChange({
+                ...record,
+                content: e.target.value
+              })}
+              placeholder="e.g., 192.168.1.1"
+            />
+          </div>
+          {record.type === 'MX' && (
+            <div className="space-y-2">
+              <Label>Priority</Label>
+              <Input
+                type="number"
+                value={record.priority || ''}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  onRecordChange({
+                    ...record,
+                    priority: parseInt(e.target.value) || undefined
+                  })}
+              />
+            </div>
+          )}
+          {(record.type === 'A' || record.type === 'AAAA' || record.type === 'CNAME') && (
+            <div className="flex items-center space-x-2">
+              <Switch
+                checked={record.proxied || false}
+                onCheckedChange={(checked: boolean) =>
+                  onRecordChange({
+                    ...record,
+                    proxied: checked
+                  })
+                }
+              />
+              <Label>Proxied through Cloudflare</Label>
+            </div>
+          )}
+          <Button onClick={onAdd} className="w-full">
+            Create Record
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dns/ImportRecordsDialog.tsx
+++ b/src/components/dns/ImportRecordsDialog.tsx
@@ -1,0 +1,48 @@
+import { ChangeEvent } from 'react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Upload } from 'lucide-react';
+
+export interface ImportRecordsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  data: string;
+  onDataChange: (val: string) => void;
+  onImport: () => void;
+}
+
+export function ImportRecordsDialog({ open, onOpenChange, data, onDataChange, onImport }: ImportRecordsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Upload className="h-4 w-4 mr-2" />
+          Import
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Import DNS Records</DialogTitle>
+          <DialogDescription>
+            Import DNS records from JSON format
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>JSON Data</Label>
+            <textarea
+              className="w-full h-32 p-2 border rounded-md bg-background"
+              value={data}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onDataChange(e.target.value)}
+              placeholder="Paste your JSON data here..."
+            />
+          </div>
+          <Button onClick={onImport} className="w-full">
+            Import Records
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dns/RecordRow.tsx
+++ b/src/components/dns/RecordRow.tsx
@@ -1,0 +1,173 @@
+import { useState, useEffect, type ChangeEvent } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { RecordType, DNSRecord } from '@/types/dns';
+import { Edit2, Trash2, Save, X } from 'lucide-react';
+
+export interface RecordRowProps {
+  record: DNSRecord;
+  isEditing: boolean;
+  onEdit: () => void;
+  onSave: (record: DNSRecord) => void;
+  onCancel: () => void;
+  onDelete: () => void;
+}
+
+export function RecordRow({ record, isEditing, onEdit, onSave, onCancel, onDelete }: RecordRowProps) {
+  const [editedRecord, setEditedRecord] = useState(record);
+
+  useEffect(() => {
+    setEditedRecord(record);
+  }, [record]);
+
+  if (isEditing) {
+    return (
+      <div className="p-4 border rounded-lg bg-muted/50">
+        <div className="grid grid-cols-12 gap-4 items-center">
+          <div className="col-span-2">
+            <Select
+              value={editedRecord.type}
+              onValueChange={(value: RecordType) => setEditedRecord({
+                ...editedRecord,
+                type: value
+              })}
+            >
+              <SelectTrigger className="h-8">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {['A','AAAA','CNAME','MX','TXT','SRV','NS','PTR','CAA'].map((type: RecordType) => (
+                  <SelectItem key={type} value={type}>
+                    {type}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="col-span-3">
+            <Input
+              value={editedRecord.name}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setEditedRecord({
+                ...editedRecord,
+                name: e.target.value
+              })}
+              className="h-8"
+            />
+          </div>
+          <div className="col-span-4">
+            <Input
+              value={editedRecord.content}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setEditedRecord({
+                ...editedRecord,
+                content: e.target.value
+              })}
+              className="h-8"
+            />
+          </div>
+          <div className="col-span-1 space-y-1">
+            <Input
+              type="number"
+              value={editedRecord.ttl}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setEditedRecord({
+                  ...editedRecord,
+                  ttl: parseInt(e.target.value) || 300,
+                })
+              }
+              className="h-8"
+            />
+            {editedRecord.type === 'MX' && (
+              <Input
+                type="number"
+                value={editedRecord.priority ?? ''}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setEditedRecord({
+                    ...editedRecord,
+                    priority: e.target.value ? parseInt(e.target.value) : undefined,
+                  })
+                }
+                className="h-8"
+              />
+            )}
+          </div>
+          <div className="col-span-1">
+            {(editedRecord.type === 'A' || editedRecord.type === 'AAAA' || editedRecord.type === 'CNAME') && (
+              <Switch
+                checked={editedRecord.proxied || false}
+                onCheckedChange={(checked: boolean) => setEditedRecord({
+                  ...editedRecord,
+                  proxied: checked
+                })}
+              />
+            )}
+          </div>
+          <div className="col-span-1 flex gap-1">
+            <Button
+              size="sm"
+              onClick={() => onSave(editedRecord)}
+              className="h-8 w-8 p-0"
+            >
+              <Save className="h-3 w-3" />
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onCancel}
+              className="h-8 w-8 p-0"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 border rounded-lg hover:bg-muted/50 transition-colors">
+      <div className="grid grid-cols-12 gap-4 items-center">
+        <div className="col-span-2">
+          <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-primary/10 text-primary">
+            {record.type}
+          </span>
+        </div>
+        <div className="col-span-3">
+          <span className="font-mono text-sm">{record.name}</span>
+        </div>
+        <div className="col-span-4">
+          <span className="font-mono text-sm break-all">{record.content}</span>
+        </div>
+        <div className="col-span-1">
+          <span className="text-sm text-muted-foreground">{record.ttl}</span>
+        </div>
+        <div className="col-span-1">
+          {record.proxied && (
+            <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200">
+              Proxied
+            </span>
+          )}
+        </div>
+        <div className="col-span-1 flex gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onEdit}
+            className="h-8 w-8 p-0"
+          >
+            <Edit2 className="h-3 w-3" />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onDelete}
+            className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dns/dns-manager.tsx
+++ b/src/components/dns/dns-manager.tsx
@@ -1,23 +1,22 @@
-import { useState, useEffect, useCallback, type ChangeEvent } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Switch } from '@/components/ui/switch';
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { useCloudflareAPI } from '@/hooks/use-cloudflare-api';
-import type { DNSRecord, Zone, RecordType } from '@/types/dns';
+import type { DNSRecord, Zone } from '@/types/dns';
 import { useToast } from '@/hooks/use-toast';
 import { storageManager } from '@/lib/storage';
-import { Plus, Download, Upload, LogOut, Edit2, Trash2, Save, X } from 'lucide-react';
+import { Download, LogOut } from 'lucide-react';
+import { RecordRow } from './RecordRow';
+import { AddRecordDialog } from './AddRecordDialog';
+import { ImportRecordsDialog } from './ImportRecordsDialog';
 
 interface DNSManagerProps {
   apiKey: string;
   onLogout: () => void;
 }
 
-const RECORD_TYPES: RecordType[] = ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'SRV', 'NS', 'PTR', 'CAA'];
 
 export function DNSManager({ apiKey, onLogout }: DNSManagerProps) {
   const [zones, setZones] = useState<Zone[]>([]);
@@ -321,112 +320,14 @@ export function DNSManager({ apiKey, onLogout }: DNSManagerProps) {
               </div>
               {selectedZone && (
                 <div className="flex gap-2">
-                  <Dialog open={showAddRecord} onOpenChange={setShowAddRecord}>
-                    <DialogTrigger asChild>
-                      <Button>
-                        <Plus className="h-4 w-4 mr-2" />
-                        Add Record
-                      </Button>
-                    </DialogTrigger>
-                    <DialogContent>
-                      <DialogHeader>
-                        <DialogTitle>Add DNS Record</DialogTitle>
-                        <DialogDescription>
-                          Create a new DNS record for {selectedZoneData?.name}
-                        </DialogDescription>
-                      </DialogHeader>
-                      <div className="space-y-4">
-                        <div className="grid grid-cols-2 gap-4">
-                          <div className="space-y-2">
-                            <Label>Type</Label>
-                            <Select
-                              value={newRecord.type}
-                              onValueChange={(value: string) =>
-                                setNewRecord(prev => ({
-                                  ...prev,
-                                  type: value as RecordType,
-                                  priority:
-                                    value === 'MX' ? prev.priority : undefined
-                                }))
-                              }
-                            >
-                              <SelectTrigger>
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {RECORD_TYPES.map((type: RecordType) => (
-                                  <SelectItem key={type} value={type}>
-                                    {type}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          </div>
-                          <div className="space-y-2">
-                            <Label>TTL</Label>
-                            <Input
-                              type="number"
-                              value={newRecord.ttl}
-                              onChange={(e: ChangeEvent<HTMLInputElement>) => setNewRecord({
-                                ...newRecord,
-                                ttl: parseInt(e.target.value) || 300
-                              })}
-                            />
-                          </div>
-                        </div>
-                        <div className="space-y-2">
-                          <Label>Name</Label>
-                          <Input
-                            value={newRecord.name}
-                            onChange={(e: ChangeEvent<HTMLInputElement>) => setNewRecord({
-                              ...newRecord,
-                              name: e.target.value
-                            })}
-                            placeholder="e.g., www or @ for root"
-                          />
-                        </div>
-                        <div className="space-y-2">
-                          <Label>Content</Label>
-                          <Input
-                            value={newRecord.content}
-                            onChange={(e: ChangeEvent<HTMLInputElement>) => setNewRecord({
-                              ...newRecord,
-                              content: e.target.value
-                            })}
-                            placeholder="e.g., 192.168.1.1"
-                          />
-                        </div>
-                        {newRecord.type === 'MX' && (
-                          <div className="space-y-2">
-                            <Label>Priority</Label>
-                            <Input
-                              type="number"
-                              value={newRecord.priority || ''}
-                              onChange={(e: ChangeEvent<HTMLInputElement>) => setNewRecord({
-                                ...newRecord,
-                                priority: parseInt(e.target.value) || undefined
-                              })}
-                            />
-                          </div>
-                        )}
-                        {(newRecord.type === 'A' || newRecord.type === 'AAAA' || newRecord.type === 'CNAME') && (
-                          <div className="flex items-center space-x-2">
-                            <Switch
-                              checked={newRecord.proxied || false}
-                              onCheckedChange={(checked: boolean) => setNewRecord({
-                                ...newRecord,
-                                proxied: checked
-                              })}
-                            />
-                            <Label>Proxied through Cloudflare</Label>
-                          </div>
-                        )}
-                        <Button onClick={handleAddRecord} className="w-full">
-                          Create Record
-                        </Button>
-                      </div>
-                    </DialogContent>
-                  </Dialog>
+                  <AddRecordDialog
+                    open={showAddRecord}
+                    onOpenChange={setShowAddRecord}
+                    record={newRecord}
+                    onRecordChange={setNewRecord}
+                    onAdd={handleAddRecord}
+                    zoneName={selectedZoneData?.name}
+                  />
                 </div>
               )}
             </div>
@@ -440,36 +341,13 @@ export function DNSManager({ apiKey, onLogout }: DNSManagerProps) {
               <div className="flex items-center justify-between">
                 <CardTitle>DNS Records</CardTitle>
                 <div className="flex gap-2">
-                  <Dialog open={showImport} onOpenChange={setShowImport}>
-                    <DialogTrigger asChild>
-                      <Button variant="outline" size="sm">
-                        <Upload className="h-4 w-4 mr-2" />
-                        Import
-                      </Button>
-                    </DialogTrigger>
-                    <DialogContent>
-                      <DialogHeader>
-                        <DialogTitle>Import DNS Records</DialogTitle>
-                        <DialogDescription>
-                          Import DNS records from JSON format
-                        </DialogDescription>
-                      </DialogHeader>
-                      <div className="space-y-4">
-                        <div className="space-y-2">
-                          <Label>JSON Data</Label>
-                          <textarea
-                            className="w-full h-32 p-2 border rounded-md bg-background"
-                            value={importData}
-                            onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setImportData(e.target.value)}
-                            placeholder="Paste your JSON data here..."
-                          />
-                        </div>
-                        <Button onClick={handleImport} className="w-full">
-                          Import Records
-                        </Button>
-                      </div>
-                    </DialogContent>
-                  </Dialog>
+                  <ImportRecordsDialog
+                    open={showImport}
+                    onOpenChange={setShowImport}
+                    data={importData}
+                    onDataChange={setImportData}
+                    onImport={handleImport}
+                  />
                   
                   <Select onValueChange={(format: 'json' | 'csv' | 'bind') => handleExport(format)}>
                     <SelectTrigger className="w-32">
@@ -515,169 +393,3 @@ export function DNSManager({ apiKey, onLogout }: DNSManagerProps) {
   );
 }
 
-interface RecordRowProps {
-  record: DNSRecord;
-  isEditing: boolean;
-  onEdit: () => void;
-  onSave: (record: DNSRecord) => void;
-  onCancel: () => void;
-  onDelete: () => void;
-}
-
-function RecordRow({ record, isEditing, onEdit, onSave, onCancel, onDelete }: RecordRowProps) {
-  const [editedRecord, setEditedRecord] = useState(record);
-
-  useEffect(() => {
-    setEditedRecord(record);
-  }, [record]);
-
-  if (isEditing) {
-    return (
-      <div className="p-4 border rounded-lg bg-muted/50">
-        <div className="grid grid-cols-12 gap-4 items-center">
-          <div className="col-span-2">
-            <Select
-              value={editedRecord.type}
-              onValueChange={(value: RecordType) => setEditedRecord({
-                ...editedRecord,
-                type: value
-              })}
-            >
-              <SelectTrigger className="h-8">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {RECORD_TYPES.map((type: RecordType) => (
-                  <SelectItem key={type} value={type}>
-                    {type}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="col-span-3">
-            <Input
-              value={editedRecord.name}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setEditedRecord({
-                ...editedRecord,
-                name: e.target.value
-              })}
-              className="h-8"
-            />
-          </div>
-          <div className="col-span-4">
-            <Input
-              value={editedRecord.content}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setEditedRecord({
-                ...editedRecord,
-                content: e.target.value
-              })}
-              className="h-8"
-            />
-          </div>
-          <div className="col-span-1 space-y-1">
-            <Input
-              type="number"
-              value={editedRecord.ttl}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                setEditedRecord({
-                  ...editedRecord,
-                  ttl: parseInt(e.target.value) || 300,
-                })
-              }
-              className="h-8"
-            />
-            {editedRecord.type === 'MX' && (
-              <Input
-                type="number"
-                value={editedRecord.priority ?? ''}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                  setEditedRecord({
-                    ...editedRecord,
-                    priority: e.target.value
-                      ? parseInt(e.target.value)
-                      : undefined,
-                  })
-                }
-                className="h-8"
-              />
-            )}
-          </div>
-          <div className="col-span-1">
-            {(editedRecord.type === 'A' || editedRecord.type === 'AAAA' || editedRecord.type === 'CNAME') && (
-              <Switch
-                checked={editedRecord.proxied || false}
-                onCheckedChange={(checked: boolean) => setEditedRecord({
-                  ...editedRecord,
-                  proxied: checked
-                })}
-              />
-            )}
-          </div>
-          <div className="col-span-1 flex gap-1">
-            <Button
-              size="sm"
-              onClick={() => onSave(editedRecord)}
-              className="h-8 w-8 p-0"
-            >
-              <Save className="h-3 w-3" />
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={onCancel}
-              className="h-8 w-8 p-0"
-            >
-              <X className="h-3 w-3" />
-            </Button>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="p-4 border rounded-lg hover:bg-muted/50 transition-colors">
-      <div className="grid grid-cols-12 gap-4 items-center">
-        <div className="col-span-2">
-          <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-primary/10 text-primary">
-            {record.type}
-          </span>
-        </div>
-        <div className="col-span-3">
-          <span className="font-mono text-sm">{record.name}</span>
-        </div>
-        <div className="col-span-4">
-          <span className="font-mono text-sm break-all">{record.content}</span>
-        </div>
-        <div className="col-span-1">
-          <span className="text-sm text-muted-foreground">{record.ttl}</span>
-        </div>
-        <div className="col-span-1">
-          {record.proxied && (
-            <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200">
-              Proxied
-            </span>
-          )}
-        </div>
-        <div className="col-span-1 flex gap-1">
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onEdit}
-            className="h-8 w-8 p-0"
-          >
-            <Edit2 className="h-3 w-3" />
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onDelete}
-            className="h-8 w-8 p-0 text-destructive hover:text-destructive"
-          >
-            <Trash2 className="h-3 w-3" />
-          </Button>
-        </div>
-      </div>
-    </div>
-  );}


### PR DESCRIPTION
## Summary
- extract `RecordRow` component from `dns-manager` and move to its own file
- split add-record and import dialogs into standalone components
- split `login-form` dialogs into `AddKeyDialog` and `EncryptionSettingsDialog`
- update imports to use the new dialog components

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687185e13b848325bbd7caaabc17c8a3