### PR TITLE
Refactor DNSManager into smaller components

### DIFF
--- a/src/components/dns/add-record-dialog.tsx
+++ b/src/components/dns/add-record-dialog.tsx
@@ -1,0 +1,147 @@
+import { ChangeEvent } from 'react';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import type { DNSRecord, RecordType } from '@/types/dns';
+import { Plus } from 'lucide-react';
+
+const RECORD_TYPES: RecordType[] = ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'SRV', 'NS', 'PTR', 'CAA'];
+
+interface AddRecordDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  record: Partial<DNSRecord>;
+  onRecordChange: (record: Partial<DNSRecord>) => void;
+  onAdd: () => void;
+  zoneName?: string;
+}
+
+export function AddRecordDialog({
+  open,
+  onOpenChange,
+  record,
+  onRecordChange,
+  onAdd,
+  zoneName
+}: AddRecordDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          Add Record
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add DNS Record</DialogTitle>
+          <DialogDescription>
+            Create a new DNS record for {zoneName}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>Type</Label>
+              <Select
+                value={record.type}
+                onValueChange={(value: string) =>
+                  onRecordChange({
+                    ...record,
+                    type: value as RecordType,
+                    priority: value === 'MX' ? record.priority : undefined
+                  })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {RECORD_TYPES.map((type: RecordType) => (
+                    <SelectItem key={type} value={type}>
+                      {type}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>TTL</Label>
+              <Input
+                type="number"
+                value={record.ttl}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  onRecordChange({
+                    ...record,
+                    ttl: parseInt(e.target.value) || 300
+                  })
+                }
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Name</Label>
+            <Input
+              value={record.name}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                onRecordChange({
+                  ...record,
+                  name: e.target.value
+                })
+              }
+              placeholder="e.g., www or @ for root"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Content</Label>
+            <Input
+              value={record.content}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                onRecordChange({
+                  ...record,
+                  content: e.target.value
+                })
+              }
+              placeholder="e.g., 192.168.1.1"
+            />
+          </div>
+          {record.type === 'MX' && (
+            <div className="space-y-2">
+              <Label>Priority</Label>
+              <Input
+                type="number"
+                value={record.priority || ''}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  onRecordChange({
+                    ...record,
+                    priority: parseInt(e.target.value) || undefined
+                  })
+                }
+              />
+            </div>
+          )}
+          {(record.type === 'A' || record.type === 'AAAA' || record.type === 'CNAME') && (
+            <div className="flex items-center space-x-2">
+              <Switch
+                checked={record.proxied || false}
+                onCheckedChange={(checked: boolean) =>
+                  onRecordChange({
+                    ...record,
+                    proxied: checked
+                  })
+                }
+              />
+              <Label>Proxied through Cloudflare</Label>
+            </div>
+          )}
+          <Button onClick={onAdd} className="w-full">
+            Create Record
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dns/import-export-dialog.tsx
+++ b/src/components/dns/import-export-dialog.tsx
@@ -1,0 +1,72 @@
+import { ChangeEvent } from 'react';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { DNSRecord } from '@/types/dns';
+import { Upload, Download } from 'lucide-react';
+
+interface ImportExportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  importData: string;
+  onImportDataChange: (data: string) => void;
+  onImport: () => void;
+  onExport: (format: 'json' | 'csv' | 'bind') => void;
+}
+
+export function ImportExportDialog({
+  open,
+  onOpenChange,
+  importData,
+  onImportDataChange,
+  onImport,
+  onExport
+}: ImportExportDialogProps) {
+  return (
+    <div className="flex gap-2">
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogTrigger asChild>
+          <Button variant="outline" size="sm">
+            <Upload className="h-4 w-4 mr-2" />
+            Import
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Import DNS Records</DialogTitle>
+            <DialogDescription>
+              Import DNS records from JSON format
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>JSON Data</Label>
+              <textarea
+                className="w-full h-32 p-2 border rounded-md bg-background"
+                value={importData}
+                onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onImportDataChange(e.target.value)}
+                placeholder="Paste your JSON data here..."
+              />
+            </div>
+            <Button onClick={onImport} className="w-full">
+              Import Records
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Select onValueChange={(format: 'json' | 'csv' | 'bind') => onExport(format)}>
+        <SelectTrigger className="w-32">
+          <Download className="h-4 w-4 mr-2" />
+          <SelectValue placeholder="Export" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="json">JSON</SelectItem>
+          <SelectItem value="csv">CSV</SelectItem>
+          <SelectItem value="bind">BIND</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/components/dns/record-row.tsx
+++ b/src/components/dns/record-row.tsx
@@ -1,0 +1,177 @@
+import { ChangeEvent, useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Edit2, Save, Trash2, X } from 'lucide-react';
+import type { DNSRecord, RecordType } from '@/types/dns';
+
+const RECORD_TYPES: RecordType[] = ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'SRV', 'NS', 'PTR', 'CAA'];
+
+interface RecordRowProps {
+  record: DNSRecord;
+  isEditing: boolean;
+  onEdit: () => void;
+  onSave: (record: DNSRecord) => void;
+  onCancel: () => void;
+  onDelete: () => void;
+}
+
+export function RecordRow({ record, isEditing, onEdit, onSave, onCancel, onDelete }: RecordRowProps) {
+  const [editedRecord, setEditedRecord] = useState(record);
+
+  useEffect(() => {
+    setEditedRecord(record);
+  }, [record]);
+
+  if (isEditing) {
+    return (
+      <div className="p-4 border rounded-lg bg-muted/50">
+        <div className="grid grid-cols-12 gap-4 items-center">
+          <div className="col-span-2">
+            <Select
+              value={editedRecord.type}
+              onValueChange={(value: RecordType) => setEditedRecord({
+                ...editedRecord,
+                type: value
+              })}
+            >
+              <SelectTrigger className="h-8">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RECORD_TYPES.map((type: RecordType) => (
+                  <SelectItem key={type} value={type}>
+                    {type}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="col-span-3">
+            <Input
+              value={editedRecord.name}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setEditedRecord({
+                ...editedRecord,
+                name: e.target.value
+              })}
+              className="h-8"
+            />
+          </div>
+          <div className="col-span-4">
+            <Input
+              value={editedRecord.content}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setEditedRecord({
+                ...editedRecord,
+                content: e.target.value
+              })}
+              className="h-8"
+            />
+          </div>
+          <div className="col-span-1 space-y-1">
+            <Input
+              type="number"
+              value={editedRecord.ttl}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setEditedRecord({
+                  ...editedRecord,
+                  ttl: parseInt(e.target.value) || 300,
+                })
+              }
+              className="h-8"
+            />
+            {editedRecord.type === 'MX' && (
+              <Input
+                type="number"
+                value={editedRecord.priority ?? ''}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setEditedRecord({
+                    ...editedRecord,
+                    priority: e.target.value
+                      ? parseInt(e.target.value)
+                      : undefined,
+                  })
+                }
+                className="h-8"
+              />
+            )}
+          </div>
+          <div className="col-span-1">
+            {(editedRecord.type === 'A' || editedRecord.type === 'AAAA' || editedRecord.type === 'CNAME') && (
+              <Switch
+                checked={editedRecord.proxied || false}
+                onCheckedChange={(checked: boolean) => setEditedRecord({
+                  ...editedRecord,
+                  proxied: checked
+                })}
+              />
+            )}
+          </div>
+          <div className="col-span-1 flex gap-1">
+            <Button
+              size="sm"
+              onClick={() => onSave(editedRecord)}
+              className="h-8 w-8 p-0"
+            >
+              <Save className="h-3 w-3" />
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onCancel}
+              className="h-8 w-8 p-0"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 border rounded-lg hover:bg-muted/50 transition-colors">
+      <div className="grid grid-cols-12 gap-4 items-center">
+        <div className="col-span-2">
+          <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-primary/10 text-primary">
+            {record.type}
+          </span>
+        </div>
+        <div className="col-span-3">
+          <span className="font-mono text-sm">{record.name}</span>
+        </div>
+        <div className="col-span-4">
+          <span className="font-mono text-sm break-all">{record.content}</span>
+        </div>
+        <div className="col-span-1">
+          <span className="text-sm text-muted-foreground">{record.ttl}</span>
+        </div>
+        <div className="col-span-1">
+          {record.proxied && (
+            <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200">
+              Proxied
+            </span>
+          )}
+        </div>
+        <div className="col-span-1 flex gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onEdit}
+            className="h-8 w-8 p-0"
+          >
+            <Edit2 className="h-3 w-3" />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onDelete}
+            className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extract `AddRecordDialog`, `ImportExportDialog`, and `RecordRow` into their own files
- simplify `DNSManager` by importing the new components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687185e565308325a7584da5e58886b5