### PR TITLE
Fix benchmark result condition

### DIFF
--- a/src/components/auth/EncryptionSettingsDialog.tsx
+++ b/src/components/auth/EncryptionSettingsDialog.tsx
@@ -70,7 +70,7 @@ export function EncryptionSettingsDialog({ open, onOpenChange, settings, onSetti
               Update
             </Button>
           </div>
-          {benchmarkResult && (
+          {benchmarkResult !== null && (
             <p className="text-sm text-muted-foreground">
               Last benchmark: {benchmarkResult.toFixed(2)}ms
             </p>


### PR DESCRIPTION
## Summary
- ensure benchmark result displays only when it isn't null

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687435e5c898832581d1fc13146aabe7