### PR TITLE
Fix CloudflareAPI constructor

### DIFF
--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -6,7 +6,7 @@ export class CloudflareAPI {
   private apiKey: string;
   private baseUrl: string;
 
-  constructor(apiKey: string, baseUrl: string = ((typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_CLOUDFLARE_API_BASE) ?? DEFAULT_CLOUDFLARE_API_BASE)) {
+  constructor(apiKey: string, baseUrl: string = import.meta.env?.VITE_CLOUDFLARE_API_BASE ?? DEFAULT_CLOUDFLARE_API_BASE) {
     this.apiKey = apiKey;
     this.baseUrl = baseUrl;
   }


### PR DESCRIPTION
## Summary
- use `ImportMetaEnv` typed env var for Cloudflare base URL

## Testing
- `npm test`
- `npx tsc --noEmit --project tsconfig.app.json` *(fails: ChangeEvent imports need `type` keyword)*

------
https://chatgpt.com/codex/tasks/task_e_687436df90148325852623867b4e052f