### PR TITLE
Fix type imports for verbatimModuleSyntax

### DIFF
--- a/src/components/auth/AddKeyDialog.tsx
+++ b/src/components/auth/AddKeyDialog.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/components/auth/EncryptionSettingsDialog.tsx
+++ b/src/components/auth/EncryptionSettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/components/dns/AddRecordDialog.tsx
+++ b/src/components/dns/AddRecordDialog.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/components/dns/ImportRecordsDialog.tsx
+++ b/src/components/dns/ImportRecordsDialog.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';

--- a/src/components/dns/RecordRow.tsx
+++ b/src/components/dns/RecordRow.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, type ChangeEvent } from 'react';
+import { useState, useEffect } from 'react';
+import type { ChangeEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
-import { RecordType, DNSRecord } from '@/types/dns';
+import type { RecordType, DNSRecord } from '@/types/dns';
 import { Edit2, Trash2, Save, X } from 'lucide-react';
 
 export interface RecordRowProps {

--- a/src/components/dns/add-record-dialog.tsx
+++ b/src/components/dns/add-record-dialog.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/src/components/dns/import-export-dialog.tsx
+++ b/src/components/dns/import-export-dialog.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import type { ChangeEvent } from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';

--- a/src/components/dns/record-row.tsx
+++ b/src/components/dns/record-row.tsx
@@ -1,4 +1,5 @@
-import { ChangeEvent, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';


### PR DESCRIPTION
## Summary
- use `import type` for `ChangeEvent` and `RecordType`

## Testing
- `npm run lint` *(fails: @typescript-eslint rules)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687436d26b248325ad6ae80b1eedeeca