### PR TITLE
Remove obsolete ImportRecordsDialog prop

### DIFF
--- a/src/components/dns/dns-manager.tsx
+++ b/src/components/dns/dns-manager.tsx
@@ -347,8 +347,6 @@ export function DNSManager({ apiKey, onLogout }: DNSManagerProps) {
                     data={importData}
                     onDataChange={setImportData}
                     onImport={handleImport}
-                    onExport={handleExport}
-
                   />
                   
                   <Select onValueChange={(format: 'json' | 'csv' | 'bind') => handleExport(format)}>


### PR DESCRIPTION
## Summary
- drop `onExport` prop from `ImportRecordsDialog`
- compile TypeScript to ensure no type mismatches

## Testing
- `npx tsc -b`

------
https://chatgpt.com/codex/tasks/task_e_68753b369224832585aad5c19dccd4a3