### PR TITLE
Enable dark mode by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
   };
 
   return (
-    <div className="dark min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-background text-foreground">
       {isAuthenticated ? (
         <DNSManager apiKey={apiKey} onLogout={handleLogout} />
       ) : (


### PR DESCRIPTION
## Summary
- add `dark` class to `html` tag so the UI loads in dark mode before JS
- remove redundant `dark` class from `App` root container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c11696c708325a3561b1ee7fe2f0b