### PR TITLE
Add TypeScript CORS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ By default the app talks to the real Cloudflare API at
 `VITE_CLOUDFLARE_API_BASE` environment variable, which is useful when working
 with a mock API during development.
 
+If the browser blocks requests to the Cloudflare API because of CORS
+restrictions, you can run the included `proxy-server.ts` to forward requests
+locally with permissive CORS headers:
+
+```bash
+npm run proxy
+```
+
+Then start the app pointing at the proxy:
+
+```bash
+VITE_CLOUDFLARE_API_BASE=http://localhost:8787 npm run dev
+```
+
 Create a `.env` file with your desired base URL:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "tsx --test test/*.test.ts"
+    "test": "tsx --test test/*.test.ts",
+    "proxy": "tsx proxy-server.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",

--- a/proxy-server.ts
+++ b/proxy-server.ts
@@ -1,0 +1,52 @@
+import http from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+const API_BASE = 'https://api.cloudflare.com/client/v4';
+const PORT = Number(process.env.PORT ?? 8787);
+
+function sendCorsHeaders(res: ServerResponse): void {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,PATCH,OPTIONS');
+}
+
+const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  if (req.method === 'OPTIONS') {
+    sendCorsHeaders(res);
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const chunks: Buffer[] = [];
+  req.on('data', chunk => chunks.push(chunk as Buffer));
+  req.on('end', async () => {
+    const body = Buffer.concat(chunks);
+    try {
+      const cfRes = await fetch(`${API_BASE}${req.url}`, {
+        method: req.method,
+        headers: {
+          ...req.headers,
+          host: 'api.cloudflare.com',
+        } as Record<string, string>,
+        body: req.method === 'GET' || req.method === 'HEAD' ? undefined : body,
+      });
+
+      res.writeHead(cfRes.status, Object.fromEntries(cfRes.headers.entries()));
+      sendCorsHeaders(res);
+      if (cfRes.body) {
+        cfRes.body.pipe(res);
+      } else {
+        res.end();
+      }
+    } catch (err) {
+      sendCorsHeaders(res);
+      res.writeHead(500);
+      res.end(String(err));
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Proxy listening on http://localhost:${PORT}`);
+});

--- a/src/components/dns/dns-manager.tsx
+++ b/src/components/dns/dns-manager.tsx
@@ -7,7 +7,7 @@ import { useCloudflareAPI } from '@/hooks/use-cloudflare-api';
 import type { DNSRecord, Zone } from '@/types/dns';
 import { useToast } from '@/hooks/use-toast';
 import { storageManager } from '@/lib/storage';
-import { Download, LogOut } from 'lucide-react';
+import { LogOut } from 'lucide-react';
 import { AddRecordDialog } from './AddRecordDialog';
 import { ImportExportDialog } from './import-export-dialog';
 import { RecordRow } from './RecordRow';


### PR DESCRIPTION
## Summary
- convert proxy-server.js to proxy-server.ts
- update proxy npm script to use tsx
- document updated script in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c133a1c308325acf1a66215e19a4f