### PR TITLE
Add dev:proxy script for easier local proxy usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Then start the app pointing at the proxy:
 VITE_CLOUDFLARE_API_BASE=http://localhost:8787 npm run dev
 ```
 
+Or launch both in one step:
+
+```bash
+npm run dev:proxy
+```
+
 Create a `.env` file with your desired base URL:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:proxy": "npm-run-all -p proxy dev",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- add `dev:proxy` script that runs the Cloudflare proxy and the Vite dev server in parallel
- document the new script in the development instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c1a32d5088325a15aba34c7bbd96c