### PR TITLE
Fix header handling in proxy-server

### DIFF
--- a/proxy-server.ts
+++ b/proxy-server.ts
@@ -32,8 +32,11 @@ const server = http.createServer(async (req: IncomingMessage, res: ServerRespons
         body: req.method === 'GET' || req.method === 'HEAD' ? undefined : body,
       });
 
-      res.writeHead(cfRes.status, Object.fromEntries(cfRes.headers.entries()));
-      sendCorsHeaders(res);
+      const headers = Object.fromEntries(cfRes.headers.entries());
+      headers['Access-Control-Allow-Origin'] = '*';
+      headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization';
+      headers['Access-Control-Allow-Methods'] = 'GET,POST,PUT,DELETE,PATCH,OPTIONS';
+      res.writeHead(cfRes.status, headers);
       if (cfRes.body) {
         cfRes.body.pipe(res);
       } else {


### PR DESCRIPTION
## Summary
- avoid setting CORS headers after they are sent
- merge Cloudflare response headers with CORS headers before responding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c1bbdf61c8325aa30fafc7fd9b03d