### PR TITLE
Add global API key support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { storageManager } from '@/lib/storage';
 function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [apiKey, setApiKey] = useState<string>('');
+  const [email, setEmail] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     // Check if there's an active session
@@ -17,8 +18,9 @@ function App() {
     }
   }, []);
 
-  const handleLogin = (decryptedApiKey: string) => {
+  const handleLogin = (decryptedApiKey: string, keyEmail?: string) => {
     setApiKey(decryptedApiKey);
+    setEmail(keyEmail);
     setIsAuthenticated(true);
   };
 
@@ -30,7 +32,7 @@ function App() {
   return (
     <div className="min-h-screen bg-background text-foreground">
       {isAuthenticated ? (
-        <DNSManager apiKey={apiKey} onLogout={handleLogout} />
+        <DNSManager apiKey={apiKey} email={email} onLogout={handleLogout} />
       ) : (
         <LoginForm onLogin={handleLogin} />
       )}

--- a/src/components/auth/AddKeyDialog.tsx
+++ b/src/components/auth/AddKeyDialog.tsx
@@ -12,12 +12,14 @@ export interface AddKeyDialogProps {
   onLabelChange: (val: string) => void;
   apiKey: string;
   onApiKeyChange: (val: string) => void;
+  email: string;
+  onEmailChange: (val: string) => void;
   password: string;
   onPasswordChange: (val: string) => void;
   onAdd: () => void;
 }
 
-export function AddKeyDialog({ open, onOpenChange, label, onLabelChange, apiKey, onApiKeyChange, password, onPasswordChange, onAdd }: AddKeyDialogProps) {
+export function AddKeyDialog({ open, onOpenChange, label, onLabelChange, apiKey, onApiKeyChange, email, onEmailChange, password, onPasswordChange, onAdd }: AddKeyDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
@@ -51,6 +53,16 @@ export function AddKeyDialog({ open, onOpenChange, label, onLabelChange, apiKey,
               value={apiKey}
               onChange={(e: ChangeEvent<HTMLInputElement>) => onApiKeyChange(e.target.value)}
               placeholder="Your Cloudflare API key"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-email">Account Email (optional for global keys)</Label>
+            <Input
+              id="new-email"
+              type="email"
+              value={email}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => onEmailChange(e.target.value)}
+              placeholder="you@example.com"
             />
           </div>
           <div className="space-y-2">

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -25,6 +25,7 @@ export function LoginForm({ onLogin }: LoginFormProps) {
   const [showSettings, setShowSettings] = useState(false);
   const [newKeyLabel, setNewKeyLabel] = useState('');
   const [newApiKey, setNewApiKey] = useState('');
+  const [newEmail, setNewEmail] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [encryptionSettings, setEncryptionSettings] = useState(cryptoManager.getConfig());
   const [benchmarkResult, setBenchmarkResult] = useState<number | null>(null);
@@ -50,7 +51,9 @@ export function LoginForm({ onLogin }: LoginFormProps) {
 
     setIsLoading(true);
     try {
-      const decryptedKey = await storageManager.getDecryptedApiKey(selectedKeyId, password);
+      const decrypted = await storageManager.getDecryptedApiKey(selectedKeyId, password);
+      const decryptedKey = decrypted?.key;
+      const email = decrypted?.email;
       if (!decryptedKey) {
         toast({
           title: "Error",
@@ -61,7 +64,7 @@ export function LoginForm({ onLogin }: LoginFormProps) {
       }
 
       // Verify the API key works
-      const isValid = await verifyToken(decryptedKey);
+      const isValid = await verifyToken(decryptedKey, email);
       
       if (!isValid) {
         toast({
@@ -102,7 +105,7 @@ export function LoginForm({ onLogin }: LoginFormProps) {
 
     try {
       // Test the API key first
-      const isValid = await verifyToken(newApiKey);
+      const isValid = await verifyToken(newApiKey, newEmail || undefined);
       
       if (!isValid) {
         toast({
@@ -113,10 +116,11 @@ export function LoginForm({ onLogin }: LoginFormProps) {
         return;
       }
 
-      await storageManager.addApiKey(newKeyLabel, newApiKey, newPassword);
+      await storageManager.addApiKey(newKeyLabel, newApiKey, newPassword, newEmail || undefined);
       setApiKeys(storageManager.getApiKeys());
       setNewKeyLabel('');
       setNewApiKey('');
+      setNewEmail('');
       setNewPassword('');
       setShowAddKey(false);
       
@@ -236,17 +240,19 @@ export function LoginForm({ onLogin }: LoginFormProps) {
           </Button>
 
           <div className="flex gap-2">
-            <AddKeyDialog
-              open={showAddKey}
-              onOpenChange={setShowAddKey}
-              label={newKeyLabel}
-              onLabelChange={setNewKeyLabel}
-              apiKey={newApiKey}
-              onApiKeyChange={setNewApiKey}
-              password={newPassword}
-              onPasswordChange={setNewPassword}
-              onAdd={handleAddKey}
-            />
+          <AddKeyDialog
+            open={showAddKey}
+            onOpenChange={setShowAddKey}
+            label={newKeyLabel}
+            onLabelChange={setNewKeyLabel}
+            apiKey={newApiKey}
+            onApiKeyChange={setNewApiKey}
+            email={newEmail}
+            onEmailChange={setNewEmail}
+            password={newPassword}
+            onPasswordChange={setNewPassword}
+            onAdd={handleAddKey}
+          />
 
             <EncryptionSettingsDialog
               open={showSettings}

--- a/src/components/dns/dns-manager.tsx
+++ b/src/components/dns/dns-manager.tsx
@@ -14,11 +14,12 @@ import { RecordRow } from './RecordRow';
 
 interface DNSManagerProps {
   apiKey: string;
+  email?: string;
   onLogout: () => void;
 }
 
 
-export function DNSManager({ apiKey, onLogout }: DNSManagerProps) {
+export function DNSManager({ apiKey, email, onLogout }: DNSManagerProps) {
   const [zones, setZones] = useState<Zone[]>([]);
   const [selectedZone, setSelectedZone] = useState<string>('');
   const [records, setRecords] = useState<DNSRecord[]>([]);
@@ -42,7 +43,7 @@ export function DNSManager({ apiKey, onLogout }: DNSManagerProps) {
     createDNSRecord,
     updateDNSRecord,
     deleteDNSRecord,
-  } = useCloudflareAPI(apiKey);
+  } = useCloudflareAPI(apiKey, email);
 
   const loadZones = useCallback(async (signal?: AbortSignal) => {
     try {

--- a/src/hooks/use-cloudflare-api.ts
+++ b/src/hooks/use-cloudflare-api.ts
@@ -2,15 +2,19 @@ import { useCallback, useMemo } from 'react';
 import { CloudflareAPI } from '../lib/cloudflare';
 import type { DNSRecord, Zone } from '../types/dns';
 
-export function useCloudflareAPI(apiKey?: string) {
-  const api = useMemo(() => (apiKey ? new CloudflareAPI(apiKey) : undefined), [apiKey]);
+export function useCloudflareAPI(apiKey?: string, email?: string) {
+  const api = useMemo(() => (apiKey ? new CloudflareAPI(apiKey, undefined, email) : undefined), [apiKey, email]);
 
   const verifyToken = useCallback(
-    async (key: string = apiKey ?? '', signal?: AbortSignal) => {
-      const client = new CloudflareAPI(key);
+    async (
+      key: string = apiKey ?? '',
+      keyEmail: string | undefined = email,
+      signal?: AbortSignal,
+    ) => {
+      const client = new CloudflareAPI(key, undefined, keyEmail);
       return client.verifyToken(signal);
     },
-    [apiKey],
+    [apiKey, email],
   );
 
   const getZones = useCallback(

--- a/src/types/dns.ts
+++ b/src/types/dns.ts
@@ -31,6 +31,8 @@ export interface ApiKey {
   keyLength: number;
   algorithm: string;
   createdAt: string;
+  /** Optional email for global API key authentication */
+  email?: string;
 }
 
 export interface EncryptionConfig {

--- a/test/useCloudflareApi.test.ts
+++ b/test/useCloudflareApi.test.ts
@@ -46,6 +46,31 @@ test('verifyToken calls Cloudflare endpoint', async () => {
   globalThis.fetch = originalFetch;
 });
 
+test('verifyToken uses email headers when provided', async () => {
+  const calls: FetchCall[] = [];
+  const originalFetch = globalThis.fetch;
+  (globalThis as unknown as { fetch: (url: string, options: FetchCallOptions) => Promise<MockResponse> }).fetch = async (url: string, options: FetchCallOptions) => {
+    calls.push({ url, options });
+    return { ok: true, json: async () => ({ success: true }) } as MockResponse;
+  };
+
+  let api: ReturnType<typeof useCloudflareAPI>;
+  function Wrapper() {
+    api = useCloudflareAPI(undefined, 'user@example.com');
+    return null;
+  }
+  act(() => {
+    create(React.createElement(Wrapper));
+  });
+
+  const result = await api.verifyToken('key', 'user@example.com');
+  assert.equal(result, true);
+  assert.equal(calls[0].options.headers['X-Auth-Key'], 'key');
+  assert.equal(calls[0].options.headers['X-Auth-Email'], 'user@example.com');
+
+  globalThis.fetch = originalFetch;
+});
+
 test('createDNSRecord posts record for provided key', async () => {
   const calls: FetchCall[] = [];
   const originalFetch = globalThis.fetch;
@@ -68,6 +93,31 @@ test('createDNSRecord posts record for provided key', async () => {
   assert.equal(calls[0].url, 'https://api.cloudflare.com/client/v4/zones/zone/dns_records');
   assert.equal(calls[0].options.method, 'POST');
   assert.equal(calls[0].options.headers.Authorization, 'Bearer abc');
+
+  globalThis.fetch = originalFetch;
+});
+
+test('createDNSRecord posts record using email auth', async () => {
+  const calls: FetchCall[] = [];
+  const originalFetch = globalThis.fetch;
+  (globalThis as unknown as { fetch: (url: string, options: FetchCallOptions) => Promise<MockResponse> }).fetch = async (url: string, options: FetchCallOptions) => {
+    calls.push({ url, options });
+    return { ok: true, json: async () => ({ success: true, result: { id: 'r2' } }) } as MockResponse;
+  };
+
+  let api: ReturnType<typeof useCloudflareAPI>;
+  function Wrapper() {
+    api = useCloudflareAPI('abc', 'me@example.com');
+    return null;
+  }
+  act(() => {
+    create(React.createElement(Wrapper));
+  });
+
+  const record = await api.createDNSRecord('zone', { type: 'A', name: 'a', content: '1.2.3.4' });
+  assert.equal(record.id, 'r2');
+  assert.equal(calls[0].options.headers['X-Auth-Key'], 'abc');
+  assert.equal(calls[0].options.headers['X-Auth-Email'], 'me@example.com');
 
   globalThis.fetch = originalFetch;
 });


### PR DESCRIPTION
## Summary
- support global API keys using X-Auth-Key/X-Auth-Email headers
- store optional email with saved keys
- surface email field in AddKeyDialog and LoginForm
- handle email in API hook, DNS manager and app state
- test new authentication flow

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687c230dbda88325af6fcb9b8e06c448