### PR TITLE
Fix CORS for token verify endpoint

### DIFF
--- a/proxy-server.ts
+++ b/proxy-server.ts
@@ -10,7 +10,10 @@ function setCorsHeaders(res: ServerResponse): void {
     return;
   }
   res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'Content-Type, Authorization, X-Auth-Email, X-Auth-Key'
+  );
   res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,PATCH,OPTIONS');
 }
 


### PR DESCRIPTION
## Summary
- allow `X-Auth-Email` and `X-Auth-Key` headers through the proxy CORS filter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cb06ed2148325a8dec00a344c695a