### PR TITLE
Add debug dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Or launch both in one step:
 npm run dev:proxy
 ```
 
+### Debugging
+
+Enable verbose logs from both the proxy server and the Cloudflare API wrapper by running the development server in debug mode:
+
+```bash
+npm run dev:debug
+```
+
+This sets `DEBUG_PROXY=1` for the proxy and `VITE_DEBUG_CF_API=1` for the React app. You can also export these variables manually and use `npm run dev:proxy`.
+
 Create a `.env` file with your desired base URL:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
         "autoprefixer": "^10.4.21",
+        "cross-env": "^7.0.3",
         "eslint": "^9.30.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
@@ -3251,6 +3252,25 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "dev:proxy": "npm-run-all -p proxy dev",
+    "dev:debug": "cross-env DEBUG_PROXY=1 VITE_DEBUG_CF_API=1 npm-run-all -p proxy dev",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
@@ -35,6 +36,7 @@
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
     "autoprefixer": "^10.4.21",
+    "cross-env": "^7.0.3",
     "eslint": "^9.30.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",


### PR DESCRIPTION
## Summary
- add `dev:debug` script with verbose logging
- document how to start development with debugging in README
- include `cross-env` for cross-platform env vars

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cdaa8c3dc8325a1c7c32aecf95d14