### PR TITLE
Fix Cloudflare token verification errors

### DIFF
--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -64,12 +64,12 @@ export function LoginForm({ onLogin }: LoginFormProps) {
       }
 
       // Verify the API key works
-      const isValid = await verifyToken(decryptedKey, email);
-      
-      if (!isValid) {
+      try {
+        await verifyToken(decryptedKey, email);
+      } catch (err) {
         toast({
           title: "Error",
-          description: "Invalid API key",
+          description: (err as Error).message,
           variant: "destructive"
         });
         return;
@@ -105,12 +105,12 @@ export function LoginForm({ onLogin }: LoginFormProps) {
 
     try {
       // Test the API key first
-      const isValid = await verifyToken(newApiKey, newEmail || undefined);
-      
-      if (!isValid) {
+      try {
+        await verifyToken(newApiKey, newEmail || undefined);
+      } catch (err) {
         toast({
           title: "Error",
-          description: "Invalid API key",
+          description: (err as Error).message,
           variant: "destructive"
         });
         return;

--- a/src/hooks/use-cloudflare-api.ts
+++ b/src/hooks/use-cloudflare-api.ts
@@ -12,7 +12,7 @@ export function useCloudflareAPI(apiKey?: string, email?: string) {
       signal?: AbortSignal,
     ) => {
       const client = new CloudflareAPI(key, undefined, keyEmail);
-      return client.verifyToken(signal);
+      await client.verifyToken(signal);
     },
     [apiKey, email],
   );

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -131,12 +131,7 @@ export class CloudflareAPI {
     });
   }
 
-  async verifyToken(signal?: AbortSignal): Promise<boolean> {
-    try {
-      await this.request<void>('/user/tokens/verify', { signal });
-      return true;
-    } catch {
-      return false;
-    }
+  async verifyToken(signal?: AbortSignal): Promise<void> {
+    await this.request<void>('/user/tokens/verify', { signal });
   }
 }

--- a/test/useCloudflareApi.test.ts
+++ b/test/useCloudflareApi.test.ts
@@ -39,7 +39,7 @@ test('verifyToken calls Cloudflare endpoint', async () => {
   });
 
   const result = await api.verifyToken('token123');
-  assert.equal(result, true);
+  assert.equal(result, undefined);
   assert.equal(calls[0].url, 'https://api.cloudflare.com/client/v4/user/tokens/verify');
   assert.equal(calls[0].options.headers.Authorization, 'Bearer token123');
 
@@ -64,7 +64,7 @@ test('verifyToken uses email headers when provided', async () => {
   });
 
   const result = await api.verifyToken('key', 'user@example.com');
-  assert.equal(result, true);
+  assert.equal(result, undefined);
   assert.equal(calls[0].options.headers['X-Auth-Key'], 'key');
   assert.equal(calls[0].options.headers['X-Auth-Email'], 'user@example.com');
 


### PR DESCRIPTION
## Summary
- bubble up error messages from CloudflareAPI.verifyToken
- adjust React hook to match new return type
- display actual error messages in login screen
- update tests for new verifyToken behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ce33c4ea0832585d75e83440c4448