### PR TITLE
Move API logic server-side

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
   "scripts": {
     "dev": "vite",
     "dev:proxy": "npm-run-all -p proxy dev",
+    "dev:server": "npm-run-all -p server dev",
     "dev:debug": "cross-env DEBUG_PROXY=1 VITE_DEBUG_CF_API=1 npm-run-all -p proxy dev",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "tsx --test test/*.test.ts",
-    "proxy": "tsx proxy-server.ts"
+    "proxy": "tsx proxy-server.ts",
+    "server": "tsx server.ts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",

--- a/server.ts
+++ b/server.ts
@@ -1,0 +1,113 @@
+import http from 'node:http';
+import { CloudflareAPI } from './src/lib/cloudflare';
+
+const PORT = Number(process.env.PORT ?? 3000);
+
+function setCors(res: http.ServerResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'Content-Type, Authorization, X-Auth-Key, X-Auth-Email'
+  );
+}
+
+function createClient(headers: http.IncomingHttpHeaders): CloudflareAPI {
+  const auth = headers['authorization'];
+  const key = headers['x-auth-key'];
+  const email = headers['x-auth-email'];
+
+  if (auth && auth.toString().startsWith('Bearer ')) {
+    const token = auth.toString().slice('Bearer '.length);
+    return new CloudflareAPI(token);
+  }
+  if (key) {
+    return new CloudflareAPI(key.toString(), undefined, email?.toString());
+  }
+  throw new Error('Missing credentials');
+}
+
+async function parseBody(req: http.IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  if (!chunks.length) return undefined;
+  const str = Buffer.concat(chunks).toString();
+  try {
+    return JSON.parse(str);
+  } catch {
+    return undefined;
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  setCors(res);
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  try {
+    if (!req.url) throw new Error('Invalid URL');
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const path = url.pathname;
+
+    const client = createClient(req.headers);
+
+    if (req.method === 'POST' && path === '/api/verify-token') {
+      await client.verifyToken();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true }));
+      return;
+    }
+
+    if (req.method === 'GET' && path === '/api/zones') {
+      const zones = await client.getZones();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ result: zones }));
+      return;
+    }
+
+    const zoneMatch = path.match(/^\/api\/zones\/([^/]+)\/dns_records(?:\/([^/]+))?$/);
+    if (zoneMatch) {
+      const zoneId = zoneMatch[1];
+      const recordId = zoneMatch[2];
+      if (req.method === 'GET' && !recordId) {
+        const records = await client.getDNSRecords(zoneId);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ result: records }));
+        return;
+      }
+      if (req.method === 'POST' && !recordId) {
+        const body = await parseBody(req);
+        const record = await client.createDNSRecord(zoneId, body ?? {});
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ result: record }));
+        return;
+      }
+      if (recordId && req.method === 'PUT') {
+        const body = await parseBody(req);
+        const record = await client.updateDNSRecord(zoneId, recordId, body ?? {});
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ result: record }));
+        return;
+      }
+      if (recordId && req.method === 'DELETE') {
+        await client.deleteDNSRecord(zoneId, recordId);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: true }));
+        return;
+      }
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: (err as Error).message }));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`API server listening on http://localhost:${PORT}`);
+});

--- a/src/hooks/use-cloudflare-api.ts
+++ b/src/hooks/use-cloudflare-api.ts
@@ -1,9 +1,19 @@
 import { useCallback, useMemo } from 'react';
-import { CloudflareAPI } from '../lib/cloudflare';
 import type { DNSRecord, Zone } from '../types/dns';
 
 export function useCloudflareAPI(apiKey?: string, email?: string) {
-  const api = useMemo(() => (apiKey ? new CloudflareAPI(apiKey, undefined, email) : undefined), [apiKey, email]);
+  const baseHeaders = useMemo(() => {
+    if (!apiKey) return undefined;
+    const h = new Headers();
+    if (email) {
+      h.set('X-Auth-Key', apiKey);
+      h.set('X-Auth-Email', email);
+    } else {
+      h.set('Authorization', `Bearer ${apiKey}`);
+    }
+    h.set('Content-Type', 'application/json');
+    return h;
+  }, [apiKey, email]);
 
   const verifyToken = useCallback(
     async (
@@ -11,50 +21,100 @@ export function useCloudflareAPI(apiKey?: string, email?: string) {
       keyEmail: string | undefined = email,
       signal?: AbortSignal,
     ) => {
-      const client = new CloudflareAPI(key, undefined, keyEmail);
-      await client.verifyToken(signal);
+      const headers = new Headers();
+      if (keyEmail) {
+        headers.set('X-Auth-Key', key);
+        headers.set('X-Auth-Email', keyEmail);
+      } else {
+        headers.set('Authorization', `Bearer ${key}`);
+      }
+      headers.set('Content-Type', 'application/json');
+      const res = await fetch('/api/verify-token', {
+        method: 'POST',
+        headers,
+        signal,
+      });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
     },
     [apiKey, email],
   );
 
   const getZones = useCallback(
     (signal?: AbortSignal): Promise<Zone[]> => {
-      if (!api) return Promise.reject(new Error('API key not provided'));
-      return api.getZones(signal);
+      if (!baseHeaders) return Promise.reject(new Error('API key not provided'));
+      return fetch('/api/zones', { headers: baseHeaders, signal })
+        .then(res => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then(data => data.result as Zone[]);
     },
-    [api],
+    [baseHeaders],
   );
 
   const getDNSRecords = useCallback(
     (zoneId: string, signal?: AbortSignal): Promise<DNSRecord[]> => {
-      if (!api) return Promise.reject(new Error('API key not provided'));
-      return api.getDNSRecords(zoneId, signal);
+      if (!baseHeaders) return Promise.reject(new Error('API key not provided'));
+      return fetch(`/api/zones/${zoneId}/dns_records`, { headers: baseHeaders, signal })
+        .then(res => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then(data => data.result as DNSRecord[]);
     },
-    [api],
+    [baseHeaders],
   );
 
   const createDNSRecord = useCallback(
     (zoneId: string, record: Partial<DNSRecord>, signal?: AbortSignal): Promise<DNSRecord> => {
-      if (!api) return Promise.reject(new Error('API key not provided'));
-      return api.createDNSRecord(zoneId, record, signal);
+      if (!baseHeaders) return Promise.reject(new Error('API key not provided'));
+      return fetch(`/api/zones/${zoneId}/dns_records`, {
+        method: 'POST',
+        headers: baseHeaders,
+        body: JSON.stringify(record),
+        signal,
+      })
+        .then(res => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then(data => data.result as DNSRecord);
     },
-    [api],
+    [baseHeaders],
   );
 
   const updateDNSRecord = useCallback(
     (zoneId: string, recordId: string, record: Partial<DNSRecord>, signal?: AbortSignal): Promise<DNSRecord> => {
-      if (!api) return Promise.reject(new Error('API key not provided'));
-      return api.updateDNSRecord(zoneId, recordId, record, signal);
+      if (!baseHeaders) return Promise.reject(new Error('API key not provided'));
+      return fetch(`/api/zones/${zoneId}/dns_records/${recordId}`, {
+        method: 'PUT',
+        headers: baseHeaders,
+        body: JSON.stringify(record),
+        signal,
+      })
+        .then(res => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then(data => data.result as DNSRecord);
     },
-    [api],
+    [baseHeaders],
   );
 
   const deleteDNSRecord = useCallback(
     (zoneId: string, recordId: string, signal?: AbortSignal): Promise<void> => {
-      if (!api) return Promise.reject(new Error('API key not provided'));
-      return api.deleteDNSRecord(zoneId, recordId, signal);
+      if (!baseHeaders) return Promise.reject(new Error('API key not provided'));
+      return fetch(`/api/zones/${zoneId}/dns_records/${recordId}`, {
+        method: 'DELETE',
+        headers: baseHeaders,
+        signal,
+      }).then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      });
     },
-    [api],
+    [baseHeaders],
   );
 
   return {

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -71,7 +71,10 @@ export class CloudflareAPI {
       method: 'POST',
       body: record,
     });
-    return (await this.client.dns.records.create({ zone_id: zoneId, ...(record as any) }, { signal })) as DNSRecord;
+    return (await this.client.dns.records.create(
+      { zone_id: zoneId, ...(record as Record<string, unknown>) },
+      { signal },
+    )) as DNSRecord;
   }
 
   async updateDNSRecord(zoneId: string, recordId: string, record: Partial<DNSRecord>, signal?: AbortSignal): Promise<DNSRecord> {
@@ -79,7 +82,11 @@ export class CloudflareAPI {
       method: 'PUT',
       body: record,
     });
-    return (await this.client.dns.records.update(recordId, { zone_id: zoneId, ...(record as any) }, { signal })) as DNSRecord;
+    return (await this.client.dns.records.update(
+      recordId,
+      { zone_id: zoneId, ...(record as Record<string, unknown>) },
+      { signal },
+    )) as DNSRecord;
   }
 
   async deleteDNSRecord(zoneId: string, recordId: string, signal?: AbortSignal): Promise<void> {

--- a/test/useCloudflareApi.test.ts
+++ b/test/useCloudflareApi.test.ts
@@ -18,7 +18,7 @@ interface FetchCall {
 
 
 
-test('verifyToken calls Cloudflare endpoint', async () => {
+test('verifyToken calls server endpoint', async () => {
   const calls: FetchCall[] = [];
   const originalFetch = globalThis.fetch;
   (globalThis as unknown as { fetch: (url: string, options: FetchCallOptions) => Promise<Response> }).fetch = async (
@@ -40,9 +40,9 @@ test('verifyToken calls Cloudflare endpoint', async () => {
 
   const result = await api.verifyToken('token123');
   assert.equal(result, undefined);
-  assert.equal(calls[0].url, 'https://api.cloudflare.com/client/v4/user/tokens/verify');
-  const headers = calls[0].options.headers as any;
-  const auth = headers.get ? headers.get('authorization') : headers.authorization;
+  assert.equal(calls[0].url, '/api/verify-token');
+  const headers = calls[0].options.headers as Headers;
+  const auth = headers.get('authorization');
   assert.equal(auth, 'Bearer token123');
 
   globalThis.fetch = originalFetch;
@@ -70,9 +70,9 @@ test('verifyToken uses email headers when provided', async () => {
 
   const result = await api.verifyToken('key', 'user@example.com');
   assert.equal(result, undefined);
-  const headers = calls[0].options.headers as any;
-  const key = headers.get ? headers.get('x-auth-key') : headers['x-auth-key'];
-  const emailHeader = headers.get ? headers.get('x-auth-email') : headers['x-auth-email'];
+  const headers = calls[0].options.headers as Headers;
+  const key = headers.get('x-auth-key');
+  const emailHeader = headers.get('x-auth-email');
   assert.equal(key, 'key');
   assert.equal(emailHeader, 'user@example.com');
 
@@ -104,10 +104,10 @@ test('createDNSRecord posts record for provided key', async () => {
 
   const record = await api.createDNSRecord('zone', { type: 'A', name: 'a', content: '1.2.3.4' });
   assert.equal(record.id, 'rec');
-  assert.equal(calls[0].url, 'https://api.cloudflare.com/client/v4/zones/zone/dns_records');
+  assert.equal(calls[0].url, '/api/zones/zone/dns_records');
   assert.equal(calls[0].options.method, 'POST');
-  const headers2 = calls[0].options.headers as any;
-  const auth2 = headers2.get ? headers2.get('authorization') : headers2.authorization;
+  const headers2 = calls[0].options.headers as Headers;
+  const auth2 = headers2.get('authorization');
   assert.equal(auth2, 'Bearer abc');
 
   globalThis.fetch = originalFetch;
@@ -138,9 +138,9 @@ test('createDNSRecord posts record using email auth', async () => {
 
   const record = await api.createDNSRecord('zone', { type: 'A', name: 'a', content: '1.2.3.4' });
   assert.equal(record.id, 'r2');
-  const headers3 = calls[0].options.headers as any;
-  const keyHeader = headers3.get ? headers3.get('x-auth-key') : headers3['x-auth-key'];
-  const emailHeader2 = headers3.get ? headers3.get('x-auth-email') : headers3['x-auth-email'];
+  const headers3 = calls[0].options.headers as Headers;
+  const keyHeader = headers3.get('x-auth-key');
+  const emailHeader2 = headers3.get('x-auth-email');
   assert.equal(keyHeader, 'abc');
   assert.equal(emailHeader2, 'me@example.com');
 


### PR DESCRIPTION
## Summary
- add a small HTTP server that exposes `/api` endpoints and calls Cloudflare
- change the React hook to call the new server instead of the Cloudflare API directly
- update tests and package scripts for the new server
- clean up `cloudflare.ts` types

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d199f1394832585dd1a927f16cae7