### PR TITLE
Fix Cloudflare API request payloads

### DIFF
--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -71,7 +71,19 @@ export class CloudflareAPI {
       method: 'POST',
       body: record,
     });
-    return (await this.client.dns.records.create({ zone_id: zoneId, ...(record as any) }, { signal })) as DNSRecord;
+    const params: Record<string, unknown> = {
+      zone_id: zoneId,
+      type: record.type,
+      name: record.name,
+      content: record.content,
+      ttl: record.ttl,
+      priority: record.priority,
+      proxied: record.proxied,
+    };
+    for (const key of Object.keys(params)) {
+      if (params[key] === undefined) delete params[key];
+    }
+    return (await this.client.dns.records.create(params as any, { signal })) as DNSRecord;
   }
 
   async updateDNSRecord(zoneId: string, recordId: string, record: Partial<DNSRecord>, signal?: AbortSignal): Promise<DNSRecord> {
@@ -79,7 +91,19 @@ export class CloudflareAPI {
       method: 'PUT',
       body: record,
     });
-    return (await this.client.dns.records.update(recordId, { zone_id: zoneId, ...(record as any) }, { signal })) as DNSRecord;
+    const params: Record<string, unknown> = {
+      zone_id: zoneId,
+      type: record.type,
+      name: record.name,
+      content: record.content,
+      ttl: record.ttl,
+      priority: record.priority,
+      proxied: record.proxied,
+    };
+    for (const key of Object.keys(params)) {
+      if (params[key] === undefined) delete params[key];
+    }
+    return (await this.client.dns.records.update(recordId, params as any, { signal })) as DNSRecord;
   }
 
   async deleteDNSRecord(zoneId: string, recordId: string, signal?: AbortSignal): Promise<void> {

--- a/test/cloudflareApi.test.ts
+++ b/test/cloudflareApi.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { CloudflareAPI } from '../src/lib/cloudflare.ts';
+
+// Ensure web fetch shims are loaded for Cloudflare client
+import 'cloudflare/shims/web';
+
+test('updateDNSRecord strips unknown fields', async () => {
+  const calls: any[] = [];
+  const originalFetch = globalThis.fetch;
+  (globalThis as any).fetch = async (url: string, options: any) => {
+    calls.push({ url, options });
+    return new Response(JSON.stringify({ result: {} }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  const api = new CloudflareAPI('token', 'http://example.com');
+  await api.updateDNSRecord('zone', 'rec', {
+    id: 'rec',
+    zone_id: 'zone',
+    zone_name: 'example.com',
+    type: 'A',
+    name: 'test',
+    content: '1.2.3.4',
+    ttl: 120,
+    created_on: 'now',
+    modified_on: 'now',
+    proxied: true,
+  });
+
+  assert.equal(calls[0].url, 'http://example.com/zones/zone/dns_records/rec');
+  const body = JSON.parse(calls[0].options.body);
+  assert.deepEqual(body, {
+    type: 'A',
+    name: 'test',
+    content: '1.2.3.4',
+    ttl: 120,
+    proxied: true,
+  });
+
+  (globalThis as any).fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- sanitize DNS record objects before sending to the Cloudflare client
- add regression test for the Cloudflare API wrapper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d20541adc83258294cd64494fcb10