### PR TITLE
Refactor server API for request handlers

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { CloudflareAPI } from './src/lib/cloudflare';
+import { ServerAPI } from './src/lib/server-api';
 
 const app = express();
 const PORT = Number(process.env.PORT ?? 8787);
@@ -34,89 +34,28 @@ app.use((req, res, next) => {
   next();
 });
 
-function createClient(req: express.Request): CloudflareAPI {
-  const auth = req.header('authorization');
-  if (auth?.startsWith('Bearer ')) {
-    if (DEBUG) console.debug('Using bearer token for Cloudflare API');
-    return new CloudflareAPI(auth.slice(7));
-  }
-  const key = req.header('x-auth-key');
-  const email = req.header('x-auth-email');
-  if (key && email) {
-    if (DEBUG) console.debug('Using key/email for Cloudflare API');
-    return new CloudflareAPI(key, undefined, email);
-  }
-  throw new Error('Missing Cloudflare credentials');
-}
-
-app.post('/api/verify-token', async (req, res) => {
-  try {
-    const client = createClient(req);
-    await client.verifyToken();
-    res.json({ success: true });
-  } catch (err) {
-    if (DEBUG) console.error(err);
-    res.status(400).json({ error: (err as Error).message });
-  }
+app.post('/api/verify-token', (req, res) => {
+  void ServerAPI.verifyToken(req, res);
 });
 
-app.get('/api/zones', async (req, res) => {
-  try {
-    const client = createClient(req);
-    const zones = await client.getZones();
-    res.json(zones);
-  } catch (err) {
-    if (DEBUG) console.error(err);
-    res.status(400).json({ error: (err as Error).message });
-  }
+app.get('/api/zones', (req, res) => {
+  void ServerAPI.getZones(req, res);
 });
 
-app.get('/api/zones/:zone/dns_records', async (req, res) => {
-  try {
-    const client = createClient(req);
-    const records = await client.getDNSRecords(req.params.zone);
-    res.json(records);
-  } catch (err) {
-    if (DEBUG) console.error(err);
-    res.status(400).json({ error: (err as Error).message });
-  }
+app.get('/api/zones/:zone/dns_records', (req, res) => {
+  void ServerAPI.getDNSRecords(req, res);
 });
 
-app.post('/api/zones/:zone/dns_records', async (req, res) => {
-  try {
-    const client = createClient(req);
-    const record = await client.createDNSRecord(req.params.zone, req.body);
-    res.json(record);
-  } catch (err) {
-    if (DEBUG) console.error(err);
-    res.status(400).json({ error: (err as Error).message });
-  }
+app.post('/api/zones/:zone/dns_records', (req, res) => {
+  void ServerAPI.createDNSRecord(req, res);
 });
 
-app.put('/api/zones/:zone/dns_records/:id', async (req, res) => {
-  try {
-    const client = createClient(req);
-    const record = await client.updateDNSRecord(
-      req.params.zone,
-      req.params.id,
-      req.body
-    );
-    res.json(record);
-  } catch (err) {
-    if (DEBUG) console.error(err);
-    res.status(400).json({ error: (err as Error).message });
-  }
+app.put('/api/zones/:zone/dns_records/:id', (req, res) => {
+  void ServerAPI.updateDNSRecord(req, res);
 });
 
-app.delete('/api/zones/:zone/dns_records/:id', async (req, res) => {
-  try {
-    const client = createClient(req);
-    await client.deleteDNSRecord(req.params.zone, req.params.id);
-    res.json({ success: true });
-  } catch (err) {
-    if (DEBUG) console.error(err);
-    res.status(400).json({ error: (err as Error).message });
-  }
+app.delete('/api/zones/:zone/dns_records/:id', (req, res) => {
+  void ServerAPI.deleteDNSRecord(req, res);
 });
 
 app.listen(PORT, () => {

--- a/src/hooks/use-cloudflare-api.ts
+++ b/src/hooks/use-cloudflare-api.ts
@@ -1,9 +1,12 @@
 import { useCallback, useMemo } from 'react';
-import { ServerAPI } from '../lib/server-api';
+import { ServerClient } from '../lib/server-client';
 import type { DNSRecord, Zone } from '../types/dns';
 
 export function useCloudflareAPI(apiKey?: string, email?: string) {
-  const api = useMemo(() => (apiKey ? new ServerAPI(apiKey, undefined, email) : undefined), [apiKey, email]);
+  const api = useMemo(
+    () => (apiKey ? new ServerClient(apiKey, undefined, email) : undefined),
+    [apiKey, email],
+  );
 
   const verifyToken = useCallback(
     async (
@@ -11,7 +14,7 @@ export function useCloudflareAPI(apiKey?: string, email?: string) {
       keyEmail: string | undefined = email,
       signal?: AbortSignal,
     ) => {
-      const client = new ServerAPI(key, undefined, keyEmail);
+      const client = new ServerClient(key, undefined, keyEmail);
       await client.verifyToken(signal);
     },
     [apiKey, email],

--- a/src/lib/server-api.ts
+++ b/src/lib/server-api.ts
@@ -1,63 +1,91 @@
-import type { DNSRecord, Zone } from '@/types/dns';
+import type { Request, Response } from 'express';
 import { CloudflareAPI } from './cloudflare';
 
-const DEBUG = Boolean(
-  (typeof process !== 'undefined' ? process.env.DEBUG_SERVER_API : undefined) ||
-    (typeof import.meta !== 'undefined'
-      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (import.meta as any).env?.VITE_DEBUG_SERVER_API
-      : undefined),
-);
+const DEBUG = Boolean(process.env.DEBUG_SERVER_API);
+
+function createClient(req: Request): CloudflareAPI {
+  const auth = req.header('authorization');
+  if (auth?.startsWith('Bearer ')) {
+    if (DEBUG) console.debug('Using bearer token for Cloudflare API');
+    return new CloudflareAPI(auth.slice(7));
+  }
+  const key = req.header('x-auth-key');
+  const email = req.header('x-auth-email');
+  if (key && email) {
+    if (DEBUG) console.debug('Using key/email for Cloudflare API');
+    return new CloudflareAPI(key, undefined, email);
+  }
+  throw new Error('Missing Cloudflare credentials');
+}
 
 export class ServerAPI {
-  private client: CloudflareAPI;
-
-  constructor(apiKey: string, baseUrl?: string, email?: string) {
-    this.client = new CloudflareAPI(apiKey, baseUrl, email);
-    if (DEBUG) {
-      console.debug('ServerAPI initialized', {
-        baseUrl,
-        email: email ? 'provided' : 'none',
-      });
+  static async verifyToken(req: Request, res: Response) {
+    try {
+      const client = createClient(req);
+      await client.verifyToken();
+      res.json({ success: true });
+    } catch (err) {
+      if (DEBUG) console.error(err);
+      res.status(400).json({ error: (err as Error).message });
     }
   }
 
-  verifyToken(signal?: AbortSignal): Promise<void> {
-    if (DEBUG) console.debug('ServerAPI.verifyToken');
-    return this.client.verifyToken(signal);
+  static async getZones(req: Request, res: Response) {
+    try {
+      const client = createClient(req);
+      const zones = await client.getZones();
+      res.json(zones);
+    } catch (err) {
+      if (DEBUG) console.error(err);
+      res.status(400).json({ error: (err as Error).message });
+    }
   }
 
-  getZones(signal?: AbortSignal): Promise<Zone[]> {
-    if (DEBUG) console.debug('ServerAPI.getZones');
-    return this.client.getZones(signal);
+  static async getDNSRecords(req: Request, res: Response) {
+    try {
+      const client = createClient(req);
+      const records = await client.getDNSRecords(req.params.zone);
+      res.json(records);
+    } catch (err) {
+      if (DEBUG) console.error(err);
+      res.status(400).json({ error: (err as Error).message });
+    }
   }
 
-  getDNSRecords(zoneId: string, signal?: AbortSignal): Promise<DNSRecord[]> {
-    if (DEBUG) console.debug('ServerAPI.getDNSRecords', { zoneId });
-    return this.client.getDNSRecords(zoneId, signal);
+  static async createDNSRecord(req: Request, res: Response) {
+    try {
+      const client = createClient(req);
+      const record = await client.createDNSRecord(req.params.zone, req.body);
+      res.json(record);
+    } catch (err) {
+      if (DEBUG) console.error(err);
+      res.status(400).json({ error: (err as Error).message });
+    }
   }
 
-  createDNSRecord(
-    zoneId: string,
-    record: Partial<DNSRecord>,
-    signal?: AbortSignal,
-  ): Promise<DNSRecord> {
-    if (DEBUG) console.debug('ServerAPI.createDNSRecord', { zoneId, record });
-    return this.client.createDNSRecord(zoneId, record, signal);
+  static async updateDNSRecord(req: Request, res: Response) {
+    try {
+      const client = createClient(req);
+      const record = await client.updateDNSRecord(
+        req.params.zone,
+        req.params.id,
+        req.body,
+      );
+      res.json(record);
+    } catch (err) {
+      if (DEBUG) console.error(err);
+      res.status(400).json({ error: (err as Error).message });
+    }
   }
 
-  updateDNSRecord(
-    zoneId: string,
-    recordId: string,
-    record: Partial<DNSRecord>,
-    signal?: AbortSignal,
-  ): Promise<DNSRecord> {
-    if (DEBUG) console.debug('ServerAPI.updateDNSRecord', { zoneId, recordId, record });
-    return this.client.updateDNSRecord(zoneId, recordId, record, signal);
-  }
-
-  deleteDNSRecord(zoneId: string, recordId: string, signal?: AbortSignal): Promise<void> {
-    if (DEBUG) console.debug('ServerAPI.deleteDNSRecord', { zoneId, recordId });
-    return this.client.deleteDNSRecord(zoneId, recordId, signal);
+  static async deleteDNSRecord(req: Request, res: Response) {
+    try {
+      const client = createClient(req);
+      await client.deleteDNSRecord(req.params.zone, req.params.id);
+      res.json({ success: true });
+    } catch (err) {
+      if (DEBUG) console.error(err);
+      res.status(400).json({ error: (err as Error).message });
+    }
   }
 }

--- a/src/lib/server-client.ts
+++ b/src/lib/server-client.ts
@@ -1,0 +1,106 @@
+import type { DNSRecord, Zone } from '@/types/dns';
+
+const DEFAULT_BASE =
+  (typeof process !== 'undefined' && process.env.SERVER_API_BASE) ||
+  (typeof import.meta !== 'undefined'
+    ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (import.meta as any).env?.VITE_SERVER_API_BASE
+    : undefined) ||
+  'http://localhost:8787/api';
+
+function authHeaders(key: string, email?: string) {
+  if (email) {
+    return {
+      'x-auth-key': key,
+      'x-auth-email': email,
+      'Content-Type': 'application/json',
+    } as Record<string, string>;
+  }
+  return {
+    authorization: `Bearer ${key}`,
+    'Content-Type': 'application/json',
+  } as Record<string, string>;
+}
+
+export class ServerClient {
+  constructor(
+    private apiKey: string,
+    private baseUrl: string = DEFAULT_BASE,
+    private email?: string,
+  ) {}
+
+  private headers() {
+    return authHeaders(this.apiKey, this.email);
+  }
+
+  async verifyToken(signal?: AbortSignal): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/verify-token`, {
+      method: 'POST',
+      headers: this.headers(),
+      signal,
+    });
+    if (!res.ok) throw new Error(await res.text());
+  }
+
+  async getZones(signal?: AbortSignal): Promise<Zone[]> {
+    const res = await fetch(`${this.baseUrl}/zones`, {
+      headers: this.headers(),
+      signal,
+    });
+    if (!res.ok) throw new Error(await res.text());
+    return res.json();
+  }
+
+  async getDNSRecords(zoneId: string, signal?: AbortSignal): Promise<DNSRecord[]> {
+    const res = await fetch(`${this.baseUrl}/zones/${zoneId}/dns_records`, {
+      headers: this.headers(),
+      signal,
+    });
+    if (!res.ok) throw new Error(await res.text());
+    return res.json();
+  }
+
+  async createDNSRecord(
+    zoneId: string,
+    record: Partial<DNSRecord>,
+    signal?: AbortSignal,
+  ): Promise<DNSRecord> {
+    const res = await fetch(`${this.baseUrl}/zones/${zoneId}/dns_records`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(record),
+      signal,
+    });
+    if (!res.ok) throw new Error(await res.text());
+    return res.json();
+  }
+
+  async updateDNSRecord(
+    zoneId: string,
+    recordId: string,
+    record: Partial<DNSRecord>,
+    signal?: AbortSignal,
+  ): Promise<DNSRecord> {
+    const res = await fetch(`${this.baseUrl}/zones/${zoneId}/dns_records/${recordId}`, {
+      method: 'PUT',
+      headers: this.headers(),
+      body: JSON.stringify(record),
+      signal,
+    });
+    if (!res.ok) throw new Error(await res.text());
+    return res.json();
+  }
+
+  async deleteDNSRecord(
+    zoneId: string,
+    recordId: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const res = await fetch(`${this.baseUrl}/zones/${zoneId}/dns_records/${recordId}`, {
+      method: 'DELETE',
+      headers: this.headers(),
+      signal,
+    });
+    if (!res.ok) throw new Error(await res.text());
+  }
+}

--- a/test/useCloudflareApi.test.ts
+++ b/test/useCloudflareApi.test.ts
@@ -18,7 +18,7 @@ interface FetchCall {
 
 
 
-test('verifyToken calls Cloudflare endpoint', async () => {
+test('verifyToken calls server endpoint', async () => {
   const calls: FetchCall[] = [];
   const originalFetch = globalThis.fetch;
   (globalThis as unknown as { fetch: (url: string, options: FetchCallOptions) => Promise<Response> }).fetch = async (
@@ -29,7 +29,7 @@ test('verifyToken calls Cloudflare endpoint', async () => {
     return new Response(JSON.stringify({ result: {} }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   };
 
-  process.env.CLOUDFLARE_API_BASE = 'http://example.com';
+  process.env.SERVER_API_BASE = 'http://localhost:8787/api';
 
   let api: ReturnType<typeof useCloudflareAPI>;
   function Wrapper() {
@@ -42,12 +42,12 @@ test('verifyToken calls Cloudflare endpoint', async () => {
 
   const result = await api.verifyToken('token123');
   assert.equal(result, undefined);
-  assert.equal(calls[0].url, 'http://example.com/user/tokens/verify');
+  assert.equal(calls[0].url, 'http://localhost:8787/api/verify-token');
   const headers = calls[0].options.headers as any;
   const auth = headers.get ? headers.get('authorization') : headers.authorization;
   assert.equal(auth, 'Bearer token123');
 
-  delete process.env.CLOUDFLARE_API_BASE;
+  delete process.env.SERVER_API_BASE;
 
   globalThis.fetch = originalFetch;
 });
@@ -63,7 +63,7 @@ test('verifyToken uses email headers when provided', async () => {
     return new Response(JSON.stringify({ result: {} }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   };
 
-  process.env.CLOUDFLARE_API_BASE = 'http://example.com';
+  process.env.SERVER_API_BASE = 'http://localhost:8787/api';
 
   let api: ReturnType<typeof useCloudflareAPI>;
   function Wrapper() {
@@ -84,7 +84,7 @@ test('verifyToken uses email headers when provided', async () => {
   assert.equal(emailHeader, 'user@example.com');
   assert.equal(bearer, undefined);
 
-  delete process.env.CLOUDFLARE_API_BASE;
+  delete process.env.SERVER_API_BASE;
   globalThis.fetch = originalFetch;
 });
 
@@ -96,13 +96,13 @@ test('createDNSRecord posts record for provided key', async () => {
     options: FetchCallOptions,
   ) => {
     calls.push({ url, options });
-    return new Response(JSON.stringify({ result: { id: 'rec' } }), {
+    return new Response(JSON.stringify({ id: 'rec' }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
   };
 
-  process.env.CLOUDFLARE_API_BASE = 'http://example.com';
+  process.env.SERVER_API_BASE = 'http://localhost:8787/api';
 
   let api: ReturnType<typeof useCloudflareAPI>;
   function Wrapper() {
@@ -115,13 +115,13 @@ test('createDNSRecord posts record for provided key', async () => {
 
   const record = await api.createDNSRecord('zone', { type: 'A', name: 'a', content: '1.2.3.4' });
   assert.equal(record.id, 'rec');
-  assert.equal(calls[0].url, 'http://example.com/zones/zone/dns_records');
+  assert.equal(calls[0].url, 'http://localhost:8787/api/zones/zone/dns_records');
   assert.equal(calls[0].options.method, 'POST');
   const headers2 = calls[0].options.headers as any;
   const auth2 = headers2.get ? headers2.get('authorization') : headers2.authorization;
   assert.equal(auth2, 'Bearer abc');
 
-  delete process.env.CLOUDFLARE_API_BASE;
+  delete process.env.SERVER_API_BASE;
   globalThis.fetch = originalFetch;
 });
 
@@ -133,13 +133,13 @@ test('createDNSRecord posts record using email auth', async () => {
     options: FetchCallOptions,
   ) => {
     calls.push({ url, options });
-    return new Response(JSON.stringify({ result: { id: 'r2' } }), {
+    return new Response(JSON.stringify({ id: 'r2' }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
   };
 
-  process.env.CLOUDFLARE_API_BASE = 'http://example.com';
+  process.env.SERVER_API_BASE = 'http://localhost:8787/api';
 
   let api: ReturnType<typeof useCloudflareAPI>;
   function Wrapper() {
@@ -152,7 +152,7 @@ test('createDNSRecord posts record using email auth', async () => {
 
   const record = await api.createDNSRecord('zone', { type: 'A', name: 'a', content: '1.2.3.4' });
   assert.equal(record.id, 'r2');
-  assert.equal(calls[0].url, 'http://example.com/zones/zone/dns_records');
+  assert.equal(calls[0].url, 'http://localhost:8787/api/zones/zone/dns_records');
   const headers3 = calls[0].options.headers as any;
   const keyHeader = headers3.get ? headers3.get('x-auth-key') : headers3['x-auth-key'];
   const emailHeader2 = headers3.get ? headers3.get('x-auth-email') : headers3['x-auth-email'];
@@ -161,6 +161,6 @@ test('createDNSRecord posts record using email auth', async () => {
   assert.equal(emailHeader2, 'me@example.com');
   assert.equal(bearer2, undefined);
 
-  delete process.env.CLOUDFLARE_API_BASE;
+  delete process.env.SERVER_API_BASE;
   globalThis.fetch = originalFetch;
 });


### PR DESCRIPTION
## Summary
- add `ServerClient` to send requests to the express server
- refactor `ServerAPI` to accept Express requests and respond directly
- update express server to call new API helpers
- update React hook to use the new `ServerClient`
- adjust tests for server based API

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d6322f1248325bb092111b6ffcf44