### PR TITLE
Export record types constant

### DIFF
--- a/src/components/dns/AddRecordDialog.tsx
+++ b/src/components/dns/AddRecordDialog.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import type { DNSRecord, RecordType } from '@/types/dns';
+import { RECORD_TYPES } from '@/types/dns';
 import { Plus } from 'lucide-react';
 
 export interface AddRecordDialogProps {
@@ -51,7 +52,7 @@ export function AddRecordDialog({ open, onOpenChange, record, onRecordChange, on
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {(['A','AAAA','CNAME','MX','TXT','SRV','NS','PTR','CAA'] as RecordType[]).map(type => (
+                  {RECORD_TYPES.map((type) => (
                     <SelectItem key={type} value={type}>
                       {type}
                     </SelectItem>

--- a/src/components/dns/RecordRow.tsx
+++ b/src/components/dns/RecordRow.tsx
@@ -5,9 +5,9 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import type { RecordType, DNSRecord } from '@/types/dns';
+import { RECORD_TYPES } from '@/types/dns';
 import { Edit2, Trash2, Save, X } from 'lucide-react';
 
-const RECORD_TYPES: RecordType[] = ['A','AAAA','CNAME','MX','TXT','SRV','NS','PTR','CAA'];
 
 export interface RecordRowProps {
   record: DNSRecord;

--- a/src/types/dns.ts
+++ b/src/types/dns.ts
@@ -40,4 +40,25 @@ export interface EncryptionConfig {
   keyLength: number;
   algorithm: string;
 }
-export type RecordType = 'A' | 'AAAA' | 'CNAME' | 'MX' | 'TXT' | 'SRV' | 'NS' | 'PTR' | 'CAA';
+export type RecordType =
+  | 'A'
+  | 'AAAA'
+  | 'CNAME'
+  | 'MX'
+  | 'TXT'
+  | 'SRV'
+  | 'NS'
+  | 'PTR'
+  | 'CAA';
+
+export const RECORD_TYPES: RecordType[] = [
+  'A',
+  'AAAA',
+  'CNAME',
+  'MX',
+  'TXT',
+  'SRV',
+  'NS',
+  'PTR',
+  'CAA'
+];


### PR DESCRIPTION
## Summary
- expose shared `RECORD_TYPES` in `src/types/dns.ts`
- use exported constant in `AddRecordDialog` and `RecordRow`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e9938ff8c83258eb33b16d42ca10e