### PR TITLE
Create dedicated API router

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { ServerAPI } from './src/lib/server-api';
+import { apiRouter } from './src/server/router';
 
 const app = express();
 const PORT = Number(process.env.PORT ?? 8787);
@@ -34,29 +34,7 @@ app.use((req, res, next) => {
   next();
 });
 
-app.post('/api/verify-token', (req, res) => {
-  void ServerAPI.verifyToken(req, res);
-});
-
-app.get('/api/zones', (req, res) => {
-  void ServerAPI.getZones(req, res);
-});
-
-app.get('/api/zones/:zone/dns_records', (req, res) => {
-  void ServerAPI.getDNSRecords(req, res);
-});
-
-app.post('/api/zones/:zone/dns_records', (req, res) => {
-  void ServerAPI.createDNSRecord(req, res);
-});
-
-app.put('/api/zones/:zone/dns_records/:id', (req, res) => {
-  void ServerAPI.updateDNSRecord(req, res);
-});
-
-app.delete('/api/zones/:zone/dns_records/:id', (req, res) => {
-  void ServerAPI.deleteDNSRecord(req, res);
-});
+app.use(apiRouter);
 
 app.listen(PORT, () => {
   console.log(`API server listening on http://localhost:${PORT}`);

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import { ServerAPI } from '../lib/server-api';
+
+export const apiRouter = Router();
+
+apiRouter.post('/api/verify-token', (req, res) => {
+  void ServerAPI.verifyToken(req, res);
+});
+
+apiRouter.get('/api/zones', (req, res) => {
+  void ServerAPI.getZones(req, res);
+});
+
+apiRouter.get('/api/zones/:zone/dns_records', (req, res) => {
+  void ServerAPI.getDNSRecords(req, res);
+});
+
+apiRouter.post('/api/zones/:zone/dns_records', (req, res) => {
+  void ServerAPI.createDNSRecord(req, res);
+});
+
+apiRouter.put('/api/zones/:zone/dns_records/:id', (req, res) => {
+  void ServerAPI.updateDNSRecord(req, res);
+});
+
+apiRouter.delete('/api/zones/:zone/dns_records/:id', (req, res) => {
+  void ServerAPI.deleteDNSRecord(req, res);
+});
+


### PR DESCRIPTION
## Summary
- add `src/server/router.ts` that registers all `/api` routes
- remove route handlers from `server.ts` and mount the router

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_687f311bd98c8325bd2a5044a21550af