### PR TITLE
Improve ServerAPI handler and add error test

### DIFF
--- a/src/lib/async-handler.ts
+++ b/src/lib/async-handler.ts
@@ -1,0 +1,14 @@
+import type { Request, Response, NextFunction } from 'express';
+
+const DEBUG = Boolean(process.env.DEBUG_SERVER_API);
+
+export function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>,
+) {
+  return function (req: Request, res: Response, next: NextFunction) {
+    Promise.resolve(fn(req, res, next)).catch((err) => {
+      if (DEBUG) console.error(err);
+      res.status(400).json({ error: (err as Error).message });
+    });
+  };
+}

--- a/src/lib/server-api.ts
+++ b/src/lib/server-api.ts
@@ -19,52 +19,40 @@ function createClient(req: Request): CloudflareAPI {
 }
 
 export class ServerAPI {
-  static async verifyToken(req: Request, res: Response) {
-    try {
+  static verifyToken() {
+    return async (req: Request, res: Response) => {
       const client = createClient(req);
       await client.verifyToken();
       res.json({ success: true });
-    } catch (err) {
-      if (DEBUG) console.error(err);
-      res.status(400).json({ error: (err as Error).message });
-    }
+    };
   }
 
-  static async getZones(req: Request, res: Response) {
-    try {
+  static getZones() {
+    return async (req: Request, res: Response) => {
       const client = createClient(req);
       const zones = await client.getZones();
       res.json(zones);
-    } catch (err) {
-      if (DEBUG) console.error(err);
-      res.status(400).json({ error: (err as Error).message });
-    }
+    };
   }
 
-  static async getDNSRecords(req: Request, res: Response) {
-    try {
+  static getDNSRecords() {
+    return async (req: Request, res: Response) => {
       const client = createClient(req);
       const records = await client.getDNSRecords(req.params.zone);
       res.json(records);
-    } catch (err) {
-      if (DEBUG) console.error(err);
-      res.status(400).json({ error: (err as Error).message });
-    }
+    };
   }
 
-  static async createDNSRecord(req: Request, res: Response) {
-    try {
+  static createDNSRecord() {
+    return async (req: Request, res: Response) => {
       const client = createClient(req);
       const record = await client.createDNSRecord(req.params.zone, req.body);
       res.json(record);
-    } catch (err) {
-      if (DEBUG) console.error(err);
-      res.status(400).json({ error: (err as Error).message });
-    }
+    };
   }
 
-  static async updateDNSRecord(req: Request, res: Response) {
-    try {
+  static updateDNSRecord() {
+    return async (req: Request, res: Response) => {
       const client = createClient(req);
       const record = await client.updateDNSRecord(
         req.params.zone,
@@ -72,20 +60,14 @@ export class ServerAPI {
         req.body,
       );
       res.json(record);
-    } catch (err) {
-      if (DEBUG) console.error(err);
-      res.status(400).json({ error: (err as Error).message });
-    }
+    };
   }
 
-  static async deleteDNSRecord(req: Request, res: Response) {
-    try {
+  static deleteDNSRecord() {
+    return async (req: Request, res: Response) => {
       const client = createClient(req);
       await client.deleteDNSRecord(req.params.zone, req.params.id);
       res.json({ success: true });
-    } catch (err) {
-      if (DEBUG) console.error(err);
-      res.status(400).json({ error: (err as Error).message });
-    }
+    };
   }
 }

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -1,29 +1,30 @@
 import { Router } from 'express';
 import { ServerAPI } from '../lib/server-api';
+import { asyncHandler } from '../lib/async-handler';
 
 export const apiRouter = Router();
 
-apiRouter.post('/api/verify-token', (req, res) => {
-  void ServerAPI.verifyToken(req, res);
-});
+apiRouter.post('/api/verify-token', asyncHandler(ServerAPI.verifyToken()));
 
-apiRouter.get('/api/zones', (req, res) => {
-  void ServerAPI.getZones(req, res);
-});
+apiRouter.get('/api/zones', asyncHandler(ServerAPI.getZones()));
 
-apiRouter.get('/api/zones/:zone/dns_records', (req, res) => {
-  void ServerAPI.getDNSRecords(req, res);
-});
+apiRouter.get(
+  '/api/zones/:zone/dns_records',
+  asyncHandler(ServerAPI.getDNSRecords()),
+);
 
-apiRouter.post('/api/zones/:zone/dns_records', (req, res) => {
-  void ServerAPI.createDNSRecord(req, res);
-});
+apiRouter.post(
+  '/api/zones/:zone/dns_records',
+  asyncHandler(ServerAPI.createDNSRecord()),
+);
 
-apiRouter.put('/api/zones/:zone/dns_records/:id', (req, res) => {
-  void ServerAPI.updateDNSRecord(req, res);
-});
+apiRouter.put(
+  '/api/zones/:zone/dns_records/:id',
+  asyncHandler(ServerAPI.updateDNSRecord()),
+);
 
-apiRouter.delete('/api/zones/:zone/dns_records/:id', (req, res) => {
-  void ServerAPI.deleteDNSRecord(req, res);
-});
+apiRouter.delete(
+  '/api/zones/:zone/dns_records/:id',
+  asyncHandler(ServerAPI.deleteDNSRecord()),
+);
 

--- a/test/apiErrorHandler.test.ts
+++ b/test/apiErrorHandler.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import express from 'express';
+
+import { apiRouter } from '../src/server/router.ts';
+
+// Ensure fetch exists for Node
+import 'cloudflare/shims/web';
+
+test('missing credentials returns 400 error', async () => {
+  const app = express();
+  app.use(express.json());
+  app.use(apiRouter);
+
+  const server = app.listen(0);
+  const { port } = server.address() as any;
+  try {
+    const res = await fetch(`http://localhost:${port}/api/zones`);
+    assert.equal(res.status, 400);
+    const data = await res.json();
+    assert.ok(/Missing Cloudflare credentials/.test(data.error));
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add asyncHandler helper for routes
- refactor ServerAPI methods to return handlers
- wrap routes with asyncHandler
- test that missing credentials return 400

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fa5bf37fc8325bb0696cb24cb0bed