### PR TITLE
Add env helper

### DIFF
--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -1,30 +1,21 @@
 import 'cloudflare/shims/web';
 import Cloudflare from 'cloudflare';
 import type { DNSRecord, Zone } from '@/types/dns';
+import { getEnv } from './env';
 
 const DEFAULT_CLOUDFLARE_API_BASE = 'https://api.cloudflare.com/client/v4';
-const DEBUG = Boolean(
-  (typeof process !== 'undefined' ? process.env.DEBUG_CF_API : undefined) ||
-    (typeof import.meta !== 'undefined'
-      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (import.meta as any).env?.VITE_DEBUG_CF_API
-      : undefined)
-);
+const DEBUG = Boolean(getEnv('DEBUG_CF_API', 'VITE_DEBUG_CF_API'));
 
 export class CloudflareAPI {
   private client: Cloudflare;
 
   constructor(
     apiKey: string,
-    baseUrl: string =
-      (typeof process !== 'undefined'
-        ? process.env.CLOUDFLARE_API_BASE
-        : undefined) ??
-      (typeof import.meta !== 'undefined'
-        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (import.meta as any).env?.VITE_CLOUDFLARE_API_BASE
-        : undefined) ??
+    baseUrl: string = getEnv(
+      'CLOUDFLARE_API_BASE',
+      'VITE_CLOUDFLARE_API_BASE',
       DEFAULT_CLOUDFLARE_API_BASE,
+    )!,
     email?: string,
   ) {
     this.client = new Cloudflare({

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,11 @@
+export function getEnv(name: string, browserKey: string, defaultValue?: string): string | undefined {
+  if (typeof process !== 'undefined' && process.env && process.env[name] !== undefined) {
+    return process.env[name];
+  }
+  if (typeof import.meta !== 'undefined') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const val = (import.meta as any).env?.[browserKey];
+    if (val !== undefined) return val;
+  }
+  return defaultValue;
+}

--- a/src/lib/server-client.ts
+++ b/src/lib/server-client.ts
@@ -1,12 +1,8 @@
 import type { DNSRecord, Zone } from '@/types/dns';
+import { getEnv } from './env';
 
 const DEFAULT_BASE =
-  (typeof process !== 'undefined' && process.env.SERVER_API_BASE) ||
-  (typeof import.meta !== 'undefined'
-    ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (import.meta as any).env?.VITE_SERVER_API_BASE
-    : undefined) ||
-  'http://localhost:8787/api';
+  getEnv('SERVER_API_BASE', 'VITE_SERVER_API_BASE', 'http://localhost:8787/api')!;
 
 function authHeaders(key: string, email?: string) {
   if (email) {


### PR DESCRIPTION
## Summary
- add `getEnv()` helper to read environment variables from browser or node
- use helper in Cloudflare and ServerClient wrappers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bdb4719a8832596f78a04f936c05e