### PR TITLE
Refactor auth headers to return HeadersInit

### DIFF
--- a/src/lib/server-client.ts
+++ b/src/lib/server-client.ts
@@ -4,18 +4,18 @@ import { getEnv } from './env';
 const DEFAULT_BASE =
   getEnv('SERVER_API_BASE', 'VITE_SERVER_API_BASE', 'http://localhost:8787/api')!;
 
-function authHeaders(key: string, email?: string) {
+function authHeaders(key: string, email?: string): HeadersInit {
   if (email) {
     return {
       'x-auth-key': key,
       'x-auth-email': email,
       'Content-Type': 'application/json',
-    } as Record<string, string>;
+    };
   }
   return {
     authorization: `Bearer ${key}`,
     'Content-Type': 'application/json',
-  } as Record<string, string>;
+  };
 }
 
 export class ServerClient {
@@ -25,7 +25,7 @@ export class ServerClient {
     private email?: string,
   ) {}
 
-  private headers() {
+  private headers(): HeadersInit {
     return authHeaders(this.apiKey, this.email);
   }
 

--- a/test/serverClient.test.ts
+++ b/test/serverClient.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { ServerClient } from '../src/lib/server-client.ts';
+
+// Ensure web fetch shims are loaded if needed
+import 'cloudflare/shims/web';
+
+test('generates bearer token headers', () => {
+  const client = new ServerClient('token', 'http://example.com');
+  const headers = (
+    client as unknown as { headers(): HeadersInit }
+  ).headers();
+  assert.deepEqual(headers, {
+    authorization: 'Bearer token',
+    'Content-Type': 'application/json',
+  });
+});
+
+test('generates email and key headers', () => {
+  const client = new ServerClient(
+    'apiKey',
+    'http://example.com',
+    'user@example.com',
+  );
+  const headers = (
+    client as unknown as { headers(): HeadersInit }
+  ).headers();
+  assert.deepEqual(headers, {
+    'x-auth-key': 'apiKey',
+    'x-auth-email': 'user@example.com',
+    'Content-Type': 'application/json',
+  });
+});


### PR DESCRIPTION
## Summary
- simplify `authHeaders` to return `HeadersInit` without casts
- type `ServerClient.headers` accordingly
- add tests for bearer token and email/key header generation

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689b4c0d04e883259d99d2b0128e6549