### PR TITLE
refactor: centralize DNS record params

### DIFF
--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -92,7 +92,7 @@ export class CloudflareAPI {
       body: record,
     });
     const params = this.buildRecordParams(zoneId, record);
-    const result = (await this.client.dns.records.create(params as any, { signal })) as DNSRecord;
+    const result = (await this.client.dns.records.create(params as Record<string, unknown>, { signal })) as DNSRecord;
     this.debugResponse(result);
     return result;
   }
@@ -104,7 +104,7 @@ export class CloudflareAPI {
       body: record,
     });
     const params = this.buildRecordParams(zoneId, record);
-    const result = (await this.client.dns.records.update(recordId, params as any, { signal })) as DNSRecord;
+    const result = (await this.client.dns.records.update(recordId, params as Record<string, unknown>, { signal })) as DNSRecord;
     this.debugResponse(result);
     return result;
   }

--- a/test/cloudflareApi.test.ts
+++ b/test/cloudflareApi.test.ts
@@ -5,10 +5,59 @@ import { CloudflareAPI } from '../src/lib/cloudflare.ts';
 // Ensure web fetch shims are loaded for Cloudflare client
 import 'cloudflare/shims/web';
 
-test('updateDNSRecord strips unknown fields', async () => {
-  const calls: any[] = [];
+interface FetchCall {
+  url: string;
+  options: RequestInit & { body?: string };
+}
+
+test('createDNSRecord strips unknown fields', async () => {
+  const calls: FetchCall[] = [];
   const originalFetch = globalThis.fetch;
-  (globalThis as any).fetch = async (url: string, options: any) => {
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = async (
+    url: string,
+    options: RequestInit & { body?: string },
+  ) => {
+    calls.push({ url, options });
+    return new Response(JSON.stringify({ result: {} }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  const api = new CloudflareAPI('token', 'http://example.com');
+  await api.createDNSRecord('zone', {
+    id: 'rec',
+    zone_id: 'zone',
+    zone_name: 'example.com',
+    type: 'A',
+    name: 'test',
+    content: '1.2.3.4',
+    ttl: 120,
+    created_on: 'now',
+    modified_on: 'now',
+    proxied: true,
+  });
+
+  assert.equal(calls[0].url, 'http://example.com/zones/zone/dns_records');
+  const body = JSON.parse(calls[0].options.body);
+  assert.deepEqual(body, {
+    type: 'A',
+    name: 'test',
+    content: '1.2.3.4',
+    ttl: 120,
+    proxied: true,
+  });
+
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+});
+
+test('updateDNSRecord strips unknown fields', async () => {
+  const calls: FetchCall[] = [];
+  const originalFetch = globalThis.fetch;
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = async (
+    url: string,
+    options: RequestInit & { body?: string },
+  ) => {
     calls.push({ url, options });
     return new Response(JSON.stringify({ result: {} }), {
       status: 200,
@@ -40,5 +89,5 @@ test('updateDNSRecord strips unknown fields', async () => {
     proxied: true,
   });
 
-  (globalThis as any).fetch = originalFetch;
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
 });


### PR DESCRIPTION
## Summary
- factor out DNS record payload builder into CloudflareAPI
- reuse record param builder in create and update
- add tests for createDNSRecord ensuring unknown fields are omitted

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type in test/apiErrorHandler.test.ts and test/useCloudflareApi.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689b4c0e687c8325ba0a5d33dd78b94f