### PR TITLE
feat: add storage fallback

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,4 +1,5 @@
 import type { EncryptionConfig } from '@/types/dns';
+import { getStorage, type StorageLike } from './storage-util';
 
 const CONFIG_STORAGE_KEY = 'encryption-settings';
 
@@ -10,15 +11,20 @@ const DEFAULT_CONFIG: EncryptionConfig = {
 
 export class CryptoManager {
   private config: EncryptionConfig;
+  private storage: StorageLike;
 
-  constructor(config: Partial<EncryptionConfig> = {}) {
+  constructor(
+    config: Partial<EncryptionConfig> = {},
+    storage?: StorageLike,
+  ) {
+    this.storage = getStorage(storage);
     const stored = this.loadFromStorage();
     this.config = { ...DEFAULT_CONFIG, ...stored, ...config };
   }
 
   private loadFromStorage(): Partial<EncryptionConfig> {
     try {
-      const stored = localStorage.getItem(CONFIG_STORAGE_KEY);
+      const stored = this.storage.getItem(CONFIG_STORAGE_KEY);
       return stored ? JSON.parse(stored) : {};
     } catch (error) {
       console.error('Failed to load encryption config:', error);
@@ -28,7 +34,7 @@ export class CryptoManager {
 
   private saveToStorage(): void {
     try {
-      localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(this.config));
+      this.storage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(this.config));
     } catch (error) {
       console.error('Failed to save encryption config:', error);
     }

--- a/src/lib/storage-util.ts
+++ b/src/lib/storage-util.ts
@@ -1,0 +1,35 @@
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+class MemoryStorage implements StorageLike {
+  private store: Record<string, string> = {};
+
+  getItem(key: string): string | null {
+    return Object.prototype.hasOwnProperty.call(this.store, key)
+      ? this.store[key]
+      : null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store[key] = String(value);
+  }
+
+  removeItem(key: string): void {
+    delete this.store[key];
+  }
+}
+
+export function getStorage(storage?: StorageLike): StorageLike {
+  if (storage) return storage;
+  try {
+    if (typeof globalThis !== 'undefined' && 'localStorage' in globalThis) {
+      return (globalThis as { localStorage: StorageLike }).localStorage;
+    }
+  } catch {
+    // Ignore access errors and fall back to memory storage
+  }
+  return new MemoryStorage();
+}

--- a/test/apiErrorHandler.test.ts
+++ b/test/apiErrorHandler.test.ts
@@ -4,6 +4,8 @@ import express from 'express';
 
 import { apiRouter } from '../src/server/router.ts';
 
+import type { AddressInfo } from 'node:net';
+
 // Ensure fetch exists for Node
 import 'cloudflare/shims/web';
 
@@ -13,7 +15,7 @@ test('missing credentials returns 400 error', async () => {
   app.use(apiRouter);
 
   const server = app.listen(0);
-  const { port } = server.address() as any;
+  const { port } = server.address() as AddressInfo;
   try {
     const res = await fetch(`http://localhost:${port}/api/zones`);
     assert.equal(res.status, 400);

--- a/test/storageManager.test.ts
+++ b/test/storageManager.test.ts
@@ -1,10 +1,14 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
+import { StorageManager, isStorageData } from '../src/lib/storage.ts';
+import { CryptoManager } from '../src/lib/crypto.ts';
 
 class LocalStorageMock {
   private store: Record<string, string> = {};
   getItem(key: string) {
-    return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;
+    return Object.prototype.hasOwnProperty.call(this.store, key)
+      ? this.store[key]
+      : null;
   }
   setItem(key: string, value: string) {
     this.store[key] = String(value);
@@ -12,23 +16,12 @@ class LocalStorageMock {
   removeItem(key: string) {
     delete this.store[key];
   }
-  clear() {
-    this.store = {};
-  }
 }
 
-interface GlobalWithLocalStorage {
-  localStorage: LocalStorageMock;
-}
-
-function resetStorage() {
-  (globalThis as unknown as GlobalWithLocalStorage).localStorage = new LocalStorageMock();
-}
-
-test('importData accepts valid data', async () => {
-  resetStorage();
-  const { StorageManager, isStorageData } = await import('../src/lib/storage.ts');
-  const mgr = new StorageManager();
+test('importData accepts valid data', () => {
+  const storage = new LocalStorageMock();
+  const crypto = new CryptoManager({}, storage);
+  const mgr = new StorageManager(storage, crypto);
   const sample = {
     apiKeys: [
       {
@@ -51,13 +44,23 @@ test('importData accepts valid data', async () => {
   assert.equal(mgr.getCurrentSession(), '1');
 });
 
-test('importData throws on invalid data without modifying existing state', async () => {
-  resetStorage();
-  const { StorageManager, isStorageData } = await import('../src/lib/storage.ts');
-  const mgr = new StorageManager();
+test('importData throws on invalid data without modifying existing state', () => {
+  const storage = new LocalStorageMock();
+  const crypto = new CryptoManager({}, storage);
+  const mgr = new StorageManager(storage, crypto);
   const bad = { apiKeys: [{ id: '1', label: 'x' }] };
   assert.equal(isStorageData(bad), false);
   assert.throws(() => mgr.importData(JSON.stringify(bad)), /Invalid data format/);
   assert.equal(mgr.getApiKeys().length, 0);
   assert.equal(mgr.getCurrentSession(), undefined);
+});
+
+test('falls back to in-memory storage when localStorage is unavailable', async () => {
+  const crypto = new CryptoManager({ iterations: 1 });
+  const mgr = new StorageManager(undefined, crypto);
+  const id = await mgr.addApiKey('label', 'secret', 'pw');
+  assert.ok(id);
+  assert.equal(mgr.getApiKeys().length, 1);
+  const mgr2 = new StorageManager(undefined, crypto);
+  assert.equal(mgr2.getApiKeys().length, 0);
 });

--- a/test/useCloudflareApi.test.ts
+++ b/test/useCloudflareApi.test.ts
@@ -16,6 +16,10 @@ interface FetchCall {
   options: FetchCallOptions;
 }
 
+type HeadersLike = Record<string, string> & {
+  get?: (key: string) => string | null;
+};
+
 
 
 test('verifyToken calls server endpoint', async () => {
@@ -43,7 +47,7 @@ test('verifyToken calls server endpoint', async () => {
   const result = await api.verifyToken('token123');
   assert.equal(result, undefined);
   assert.equal(calls[0].url, 'http://localhost:8787/api/verify-token');
-  const headers = calls[0].options.headers as any;
+  const headers = calls[0].options.headers as HeadersLike;
   const auth = headers.get ? headers.get('authorization') : headers.authorization;
   assert.equal(auth, 'Bearer token123');
 
@@ -76,7 +80,7 @@ test('verifyToken uses email headers when provided', async () => {
 
   const result = await api.verifyToken('key', 'user@example.com');
   assert.equal(result, undefined);
-  const headers = calls[0].options.headers as any;
+  const headers = calls[0].options.headers as HeadersLike;
   const key = headers.get ? headers.get('x-auth-key') : headers['x-auth-key'];
   const emailHeader = headers.get ? headers.get('x-auth-email') : headers['x-auth-email'];
   const bearer = headers.get ? headers.get('authorization') : headers.authorization;
@@ -117,7 +121,7 @@ test('createDNSRecord posts record for provided key', async () => {
   assert.equal(record.id, 'rec');
   assert.equal(calls[0].url, 'http://localhost:8787/api/zones/zone/dns_records');
   assert.equal(calls[0].options.method, 'POST');
-  const headers2 = calls[0].options.headers as any;
+  const headers2 = calls[0].options.headers as HeadersLike;
   const auth2 = headers2.get ? headers2.get('authorization') : headers2.authorization;
   assert.equal(auth2, 'Bearer abc');
 
@@ -153,7 +157,7 @@ test('createDNSRecord posts record using email auth', async () => {
   const record = await api.createDNSRecord('zone', { type: 'A', name: 'a', content: '1.2.3.4' });
   assert.equal(record.id, 'r2');
   assert.equal(calls[0].url, 'http://localhost:8787/api/zones/zone/dns_records');
-  const headers3 = calls[0].options.headers as any;
+  const headers3 = calls[0].options.headers as HeadersLike;
   const keyHeader = headers3.get ? headers3.get('x-auth-key') : headers3['x-auth-key'];
   const emailHeader2 = headers3.get ? headers3.get('x-auth-email') : headers3['x-auth-email'];
   const bearer2 = headers3.get ? headers3.get('authorization') : headers3.authorization;


### PR DESCRIPTION
## Summary
- fall back to in-memory storage when localStorage is unavailable
- allow CryptoManager and StorageManager to accept custom storage implementations
- cover storage fallback with new tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca69254e48325a0ca1893ff4f8c34