### PR TITLE
Add central API error handler and adjust tests

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { apiRouter } from './src/server/router';
+import { errorHandler } from './src/server/errorHandler';
 
 const app = express();
 const PORT = Number(process.env.PORT ?? 8787);
@@ -35,6 +36,8 @@ app.use((req, res, next) => {
 });
 
 app.use(apiRouter);
+
+app.use(errorHandler);
 
 app.listen(PORT, () => {
   console.log(`API server listening on http://localhost:${PORT}`);

--- a/src/lib/async-handler.ts
+++ b/src/lib/async-handler.ts
@@ -1,14 +1,9 @@
 import type { Request, Response, NextFunction } from 'express';
 
-const DEBUG = Boolean(process.env.DEBUG_SERVER_API);
-
 export function asyncHandler(
   fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>,
 ) {
   return function (req: Request, res: Response, next: NextFunction) {
-    Promise.resolve(fn(req, res, next)).catch((err) => {
-      if (DEBUG) console.error(err);
-      res.status(400).json({ error: (err as Error).message });
-    });
+    Promise.resolve(fn(req, res, next)).catch(next);
   };
 }

--- a/src/lib/server-api.ts
+++ b/src/lib/server-api.ts
@@ -15,7 +15,11 @@ function createClient(req: Request): CloudflareAPI {
     if (DEBUG) console.debug('Using key/email for Cloudflare API');
     return new CloudflareAPI(key, undefined, email);
   }
-  throw new Error('Missing Cloudflare credentials');
+  const err = new Error('Missing Cloudflare credentials') as Error & {
+    status?: number;
+  };
+  err.status = 400;
+  throw err;
 }
 
 export class ServerAPI {

--- a/src/server/errorHandler.ts
+++ b/src/server/errorHandler.ts
@@ -1,0 +1,16 @@
+import type { Request, Response, NextFunction } from 'express';
+
+const DEBUG = Boolean(process.env.DEBUG_SERVER_API);
+
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (DEBUG) console.error(err);
+  const status = (err as { status?: number }).status ?? 500;
+  res.status(status).json({ error: (err as Error).message });
+  void next;
+}
+

--- a/test/apiErrorHandler.test.ts
+++ b/test/apiErrorHandler.test.ts
@@ -3,6 +3,8 @@ import { test } from 'node:test';
 import express from 'express';
 
 import { apiRouter } from '../src/server/router.ts';
+import { errorHandler } from '../src/server/errorHandler.ts';
+import { asyncHandler } from '../src/lib/async-handler.ts';
 
 import type { AddressInfo } from 'node:net';
 
@@ -13,6 +15,7 @@ test('missing credentials returns 400 error', async () => {
   const app = express();
   app.use(express.json());
   app.use(apiRouter);
+  app.use(errorHandler);
 
   const server = app.listen(0);
   const { port } = server.address() as AddressInfo;
@@ -21,6 +24,30 @@ test('missing credentials returns 400 error', async () => {
     assert.equal(res.status, 400);
     const data = await res.json();
     assert.ok(/Missing Cloudflare credentials/.test(data.error));
+  } finally {
+    server.close();
+  }
+});
+
+test('generic errors return 500', async () => {
+  const app = express();
+  app.use(
+    '/api/error',
+    asyncHandler(async (_req, _res) => {
+      void _req;
+      void _res;
+      throw new Error('boom');
+    }),
+  );
+  app.use(errorHandler);
+
+  const server = app.listen(0);
+  const { port } = server.address() as AddressInfo;
+  try {
+    const res = await fetch(`http://localhost:${port}/api/error`);
+    assert.equal(res.status, 500);
+    const data = await res.json();
+    assert.ok(/boom/.test(data.error));
   } finally {
     server.close();
   }

--- a/test/serverClient.test.ts
+++ b/test/serverClient.test.ts
@@ -65,7 +65,7 @@ test('verifyToken success and error', async () => {
 
   let restore = mockFetch({ ok: true, status: 200 });
   await client.verifyToken();
-  let called = restore();
+  const called = restore();
   assert.equal(called.url, 'http://example.com/verify-token');
   assert.equal(called.init?.method, 'POST');
 
@@ -90,7 +90,7 @@ test('getZones success and error', async () => {
     body: zones,
   });
   assert.deepEqual(await client.getZones(), zones);
-  let called = restore();
+  const called = restore();
   assert.equal(called.url, 'http://example.com/zones');
 
   restore = mockFetch({
@@ -114,7 +114,7 @@ test('getDNSRecords success and error', async () => {
     body: records,
   });
   assert.deepEqual(await client.getDNSRecords('zone', undefined), records);
-  let called = restore();
+  const called = restore();
   assert.equal(called.url, 'http://example.com/zones/zone/dns_records');
 
   restore = mockFetch({
@@ -144,7 +144,7 @@ test('createDNSRecord success and error', async () => {
     await client.createDNSRecord('zone', record, undefined),
     record,
   );
-  let called = restore();
+  const called = restore();
   assert.equal(called.url, 'http://example.com/zones/zone/dns_records');
   assert.equal(called.init?.method, 'POST');
 
@@ -175,7 +175,7 @@ test('updateDNSRecord success and error', async () => {
     await client.updateDNSRecord('zone', '1', record, undefined),
     record,
   );
-  let called = restore();
+  const called = restore();
   assert.equal(
     called.url,
     'http://example.com/zones/zone/dns_records/1',
@@ -200,7 +200,7 @@ test('deleteDNSRecord success and error', async () => {
 
   let restore = mockFetch({ ok: true, status: 200 });
   await client.deleteDNSRecord('zone', '1', undefined);
-  let called = restore();
+  const called = restore();
   assert.equal(
     called.url,
     'http://example.com/zones/zone/dns_records/1',


### PR DESCRIPTION
## Summary
- Call next(err) in async handler for centralized error processing
- Introduce Express errorHandler middleware and register in server
- Add status-aware error propagation and test coverage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cefabab30832581d8bd84e56fa15d