### PR TITLE
Add benchmark validation and dedicated module

### DIFF
--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -151,7 +151,8 @@ export function LoginForm({ onLogin }: LoginFormProps) {
 
   const handleBenchmark = async () => {
     try {
-      const result = await cryptoManager.benchmark(encryptionSettings.iterations);
+      const { benchmark } = await import('@/lib/crypto-benchmark.ts');
+      const result = await benchmark(encryptionSettings.iterations);
       setBenchmarkResult(result);
       toast({
         title: "Benchmark Complete",

--- a/src/lib/crypto-benchmark.ts
+++ b/src/lib/crypto-benchmark.ts
@@ -1,0 +1,19 @@
+import { CryptoManager, cryptoManager } from './crypto.ts';
+
+export const MAX_BENCHMARK_ITERATIONS = 1_000_000;
+
+export async function benchmark(iterations: number = 10000): Promise<number> {
+  if (!Number.isInteger(iterations) || iterations <= 0 || iterations > MAX_BENCHMARK_ITERATIONS) {
+    throw new Error(`Iterations must be a positive integer not exceeding ${MAX_BENCHMARK_ITERATIONS}`);
+  }
+
+  const start = performance.now();
+  const password = 'test-password';
+  const data = 'test-data';
+
+  const config = { ...cryptoManager.getConfig(), iterations };
+  const tempCrypto = new CryptoManager(config);
+
+  await tempCrypto.encrypt(data, password);
+  return performance.now() - start;
+}

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -112,20 +112,6 @@ export class CryptoManager {
     return new TextDecoder().decode(decrypted);
   }
 
-  async benchmark(iterations: number = 10000): Promise<number> {
-    const start = performance.now();
-    const password = 'test-password';
-    const data = 'test-data';
-    
-    const testConfig = { ...this.config, iterations };
-    const tempCrypto = new CryptoManager(testConfig);
-    
-    await tempCrypto.encrypt(data, password);
-    
-    const end = performance.now();
-    return end - start;
-  }
-
   private arrayBufferToBase64(buffer: ArrayBuffer): string {
     const bytes = new Uint8Array(buffer);
     let binary = '';

--- a/test/benchmark.test.ts
+++ b/test/benchmark.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { benchmark, MAX_BENCHMARK_ITERATIONS } from '../src/lib/crypto-benchmark.ts';
+
+const TOLERANCE_MS = 50;
+
+test('benchmark returns positive duration', async () => {
+  const result = await benchmark(10);
+  assert.ok(result >= 0);
+});
+
+test('benchmark timing roughly matches external measurement', async () => {
+  const start = performance.now();
+  const result = await benchmark(10);
+  const total = performance.now() - start;
+  assert.ok(Math.abs(total - result) < TOLERANCE_MS);
+});
+
+test('benchmark rejects invalid iterations', async () => {
+  await assert.rejects(() => benchmark(0), /positive integer/);
+  await assert.rejects(() => benchmark(MAX_BENCHMARK_ITERATIONS + 1), /not exceeding/);
+  await assert.rejects(() => benchmark(1.5), /positive integer/);
+});


### PR DESCRIPTION
## Summary
- add standalone crypto benchmark module with input validation and iteration cap
- load benchmark logic dynamically from login form
- test benchmark timing and extreme iteration handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf28526e883259403517fd66bcf4f