### PR TITLE
Allow configuring CORS origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ first:
 npm run server
 ```
 
+By default the API server allows requests from any origin. Set
+`ALLOWED_ORIGIN` to restrict CORS to a specific origin:
+
+```bash
+ALLOWED_ORIGIN=http://localhost:5173 npm run server
+```
+
 Then start the app pointing at the API server:
 
 ```bash

--- a/server.ts
+++ b/server.ts
@@ -5,6 +5,7 @@ import { errorHandler } from './src/server/errorHandler';
 const app = express();
 const PORT = Number(process.env.PORT ?? 8787);
 const DEBUG = Boolean(process.env.DEBUG_SERVER);
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ?? '*';
 
 app.use(express.json());
 if (DEBUG) {
@@ -22,7 +23,7 @@ if (DEBUG) {
   });
 }
 app.use((req, res, next) => {
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Origin', ALLOWED_ORIGIN);
   res.setHeader(
     'Access-Control-Allow-Headers',
     'Content-Type, Authorization, X-Auth-Key, X-Auth-Email'


### PR DESCRIPTION
## Summary
- allow configuring CORS via `ALLOWED_ORIGIN` environment variable
- document `ALLOWED_ORIGIN` for the API server

## Testing
- `npm test`
- `npm run build` *(fails: Could not find a declaration file for module 'express', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689cf7ac0ee08325b02e9819e25240c9