### PR TITLE
Remove trailing punctuation from root render

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,4 +7,4 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>
-);
+)


### PR DESCRIPTION
## Summary
- simplify `createRoot` render call to avoid trailing punctuation

## Testing
- `npm run build` *(fails: TypeScript errors in cloudflare and server client modules)*

------
https://chatgpt.com/codex/tasks/task_e_689cfc57dd908325bc5ea37aae16b754