### PR TITLE
feat: add encryption algorithm selection

### DIFF
--- a/src/components/auth/EncryptionSettingsDialog.tsx
+++ b/src/components/auth/EncryptionSettingsDialog.tsx
@@ -4,7 +4,11 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import type { EncryptionConfig } from '@/types/dns';
+import {
+  ENCRYPTION_ALGORITHMS,
+  type EncryptionConfig,
+  type EncryptionAlgorithm,
+} from '../../types/dns';
 import { Settings } from 'lucide-react';
 
 export interface EncryptionSettingsDialogProps {
@@ -59,6 +63,24 @@ export function EncryptionSettingsDialog({ open, onOpenChange, settings, onSetti
                 <SelectItem value="128">128</SelectItem>
                 <SelectItem value="192">192</SelectItem>
                 <SelectItem value="256">256</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="algorithm">Algorithm</Label>
+            <Select
+              value={settings.algorithm}
+              onValueChange={(value) =>
+                onSettingsChange({ ...settings, algorithm: value as EncryptionAlgorithm })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ENCRYPTION_ALGORITHMS.map((alg) => (
+                  <SelectItem key={alg} value={alg}>{alg}</SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,4 +1,8 @@
-import type { ApiKey } from '@/types/dns';
+import {
+  ENCRYPTION_ALGORITHMS,
+  type ApiKey,
+  type EncryptionAlgorithm,
+} from '../types/dns';
 import { CryptoManager } from './crypto';
 import { getStorage, type StorageLike } from './storage-util';
 import { generateUUID } from './utils';
@@ -32,6 +36,7 @@ export function isStorageData(value: unknown): value is StorageData {
       typeof key.iterations === 'number' &&
       typeof key.keyLength === 'number' &&
       typeof key.algorithm === 'string' &&
+      ENCRYPTION_ALGORITHMS.includes(key.algorithm as EncryptionAlgorithm) &&
       typeof key.createdAt === 'string' &&
       (key.email === undefined || typeof key.email === 'string')
     );
@@ -146,7 +151,11 @@ export class StorageManager {
   }
 
   exportData(): string {
-    return JSON.stringify(this.data, null, 2);
+    return JSON.stringify(
+      { ...this.data, encryption: this.crypto.getConfig() },
+      null,
+      2,
+    );
   }
 
   importData(jsonData: string): void {

--- a/src/types/dns.ts
+++ b/src/types/dns.ts
@@ -21,6 +21,9 @@ export interface Zone {
   development_mode: number;
 }
 
+export const ENCRYPTION_ALGORITHMS = ['AES-GCM', 'AES-CBC'] as const;
+export type EncryptionAlgorithm = typeof ENCRYPTION_ALGORITHMS[number];
+
 export interface ApiKey {
   id: string;
   label: string;
@@ -29,7 +32,7 @@ export interface ApiKey {
   iv: string;
   iterations: number;
   keyLength: number;
-  algorithm: string;
+  algorithm: EncryptionAlgorithm;
   createdAt: string;
   /** Optional email for global API key authentication */
   email?: string;
@@ -38,7 +41,7 @@ export interface ApiKey {
 export interface EncryptionConfig {
   iterations: number;
   keyLength: number;
-  algorithm: string;
+  algorithm: EncryptionAlgorithm;
 }
 export type RecordType =
   | 'A'

--- a/test/cryptoManager.test.ts
+++ b/test/cryptoManager.test.ts
@@ -88,3 +88,14 @@ test('decrypt fails with incorrect password', async () => {
   );
   Object.defineProperty(globalThis, 'crypto', { value: original, configurable: true });
 });
+
+test('updateConfig persists algorithm selection', () => {
+  const storage = new LocalStorageMock();
+  const original = globalThis.crypto;
+  Object.defineProperty(globalThis, 'crypto', { value: new MockCrypto(), configurable: true });
+  const cryptoMgr = new CryptoManager({}, storage);
+  cryptoMgr.updateConfig({ algorithm: 'AES-CBC' });
+  const cryptoMgr2 = new CryptoManager({}, storage);
+  assert.equal(cryptoMgr2.getConfig().algorithm, 'AES-CBC');
+  Object.defineProperty(globalThis, 'crypto', { value: original, configurable: true });
+});

--- a/test/storageManager.test.ts
+++ b/test/storageManager.test.ts
@@ -32,7 +32,7 @@ test('importData accepts valid data', () => {
         iv: 'iv',
         iterations: 1,
         keyLength: 1,
-        algorithm: 'AES',
+        algorithm: 'AES-GCM',
         createdAt: new Date().toISOString(),
       },
     ],


### PR DESCRIPTION
## Summary
- restrict encryption algorithm to AES-GCM or AES-CBC
- allow selecting algorithm in encryption settings dialog and persist choice
- validate algorithm and include config in exported storage

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in serverApiValidation.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689cfc6a62548325a846d7c3c4bee1a4