### PR TITLE
refactor: centralize error handling

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { apiRouter } from './src/server/router';
-import { errorHandler } from './src/server/errorHandler';
+import { errorHandler } from './src/server/error-handler';
 
 const app = express();
 const PORT = Number(process.env.PORT ?? 8787);

--- a/src/lib/async-handler.ts
+++ b/src/lib/async-handler.ts
@@ -4,6 +4,6 @@ export function asyncHandler(
   fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>,
 ) {
   return function (req: Request, res: Response, next: NextFunction) {
-    Promise.resolve(fn(req, res, next)).catch(next);
+    Promise.resolve(fn(req, res, next)).catch((err) => next(err));
   };
 }

--- a/src/server/error-handler.ts
+++ b/src/server/error-handler.ts
@@ -6,11 +6,13 @@ export function errorHandler(
   err: unknown,
   _req: Request,
   res: Response,
-  next: NextFunction,
+  _next: NextFunction,
 ) {
   if (DEBUG) console.error(err);
-  const status = (err as { status?: number }).status ?? 500;
-  res.status(status).json({ error: (err as Error).message });
-  void next;
+  const status =
+    typeof err === 'object' && err && 'status' in err
+      ? (err as { status?: number }).status
+      : undefined;
+  res.status(status ?? 500).json({ error: (err as Error).message });
 }
 


### PR DESCRIPTION
## Summary
- forward async handler errors to Express error middleware
- add dedicated Express error handler that logs when DEBUG_SERVER_API is set
- ensure API server registers new error handler and tests cover client/server error codes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d0c4a09b083259ac5fcdee0d5b2cb