### PR TITLE
Add env parsing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,17 @@ npm run dev:debug
 ```
 
 This sets `VITE_DEBUG_CF_API=1` for the React app. You can also export this variable manually and use `npm run dev:server`.
-Setting `DEBUG_SERVER=1` enables detailed request logs from the Express server.
+
+Set `DEBUG_SERVER=1` to enable detailed request logs from the Express server and
+`DEBUG_SERVER_API=1` to log Cloudflare API requests made by the server.
+
+Boolean flags accept `1`, `true`, `yes` or `on`.
+
+The API server listens on port `8787` by default. Override it with:
+
+```bash
+PORT=3000 npm run server
+```
 
 Create a `.env` file with your desired base URL:
 

--- a/server.ts
+++ b/server.ts
@@ -1,11 +1,12 @@
 import express from 'express';
 import { apiRouter } from './src/server/router';
 import { errorHandler } from './src/server/errorHandler';
+import { getEnv, getEnvBool, getEnvNumber } from './src/lib/env';
 
 const app = express();
-const PORT = Number(process.env.PORT ?? 8787);
-const DEBUG = Boolean(process.env.DEBUG_SERVER);
-const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ?? '*';
+const PORT = getEnvNumber('PORT', 'VITE_PORT', 8787);
+const DEBUG = getEnvBool('DEBUG_SERVER', 'VITE_DEBUG_SERVER');
+const ALLOWED_ORIGIN = getEnv('ALLOWED_ORIGIN', 'VITE_ALLOWED_ORIGIN', '*')!;
 
 app.use(express.json());
 if (DEBUG) {

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -1,10 +1,10 @@
 import 'cloudflare/shims/web';
 import Cloudflare from 'cloudflare';
 import type { DNSRecord, Zone } from '@/types/dns';
-import { getEnv } from './env';
+import { getEnv, getEnvBool } from './env';
 
 const DEFAULT_CLOUDFLARE_API_BASE = 'https://api.cloudflare.com/client/v4';
-const DEBUG = Boolean(getEnv('DEBUG_CF_API', 'VITE_DEBUG_CF_API'));
+const DEBUG = getEnvBool('DEBUG_CF_API', 'VITE_DEBUG_CF_API');
 
 export class CloudflareAPI {
   private client: Cloudflare;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,11 +1,35 @@
-export function getEnv(name: string, browserKey: string, defaultValue?: string): string | undefined {
-  if (typeof process !== 'undefined' && process.env && process.env[name] !== undefined) {
+export function getEnv(
+  name: string,
+  browserKey: string,
+  defaultValue?: string,
+): string | undefined {
+  if (typeof process !== 'undefined' && process.env?.[name] !== undefined) {
     return process.env[name];
   }
   if (typeof import.meta !== 'undefined') {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const val = (import.meta as any).env?.[browserKey];
+    const val = import.meta.env?.[browserKey];
     if (val !== undefined) return val;
   }
   return defaultValue;
+}
+
+export function getEnvBool(
+  name: string,
+  browserKey: string,
+  defaultValue = false,
+): boolean {
+  const val = getEnv(name, browserKey);
+  if (val === undefined) return defaultValue;
+  return ['1', 'true', 'yes', 'on'].includes(val.toLowerCase());
+}
+
+export function getEnvNumber(
+  name: string,
+  browserKey: string,
+  defaultValue: number,
+): number {
+  const val = getEnv(name, browserKey);
+  if (val === undefined) return defaultValue;
+  const parsed = Number(val);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
 }

--- a/src/lib/server-api.ts
+++ b/src/lib/server-api.ts
@@ -1,8 +1,9 @@
 import type { Request, Response } from 'express';
 import { CloudflareAPI } from './cloudflare';
 import { dnsRecordSchema } from './validation';
+import { getEnvBool } from './env';
 
-const DEBUG = Boolean(process.env.DEBUG_SERVER_API);
+const DEBUG = getEnvBool('DEBUG_SERVER_API', 'VITE_DEBUG_SERVER_API');
 
 function createClient(req: Request): CloudflareAPI {
   const auth = req.header('authorization');

--- a/src/server/errorHandler.ts
+++ b/src/server/errorHandler.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
+import { getEnvBool } from '../lib/env';
 
-const DEBUG = Boolean(process.env.DEBUG_SERVER_API);
+const DEBUG = getEnvBool('DEBUG_SERVER_API', 'VITE_DEBUG_SERVER_API');
 
 export function errorHandler(
   err: unknown,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,9 +3,14 @@
 declare module '*.css';
 
 interface ImportMetaEnv {
+  readonly [key: string]: string | undefined;
   readonly VITE_CLOUDFLARE_API_BASE?: string;
   readonly VITE_SERVER_API_BASE?: string;
   readonly VITE_DEBUG_CF_API?: string;
+  readonly VITE_DEBUG_SERVER?: string;
+  readonly VITE_DEBUG_SERVER_API?: string;
+  readonly VITE_PORT?: string;
+  readonly VITE_ALLOWED_ORIGIN?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- add `getEnvBool` and `getEnvNumber` helpers for env parsing
- replace manual boolean/number coercions with new helpers
- improve `ImportMetaEnv` typing and document env vars

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d0c505b2083259b745837b428ac7e