### PR TITLE
Use existing API client for token verification

### DIFF
--- a/src/hooks/use-cloudflare-api.ts
+++ b/src/hooks/use-cloudflare-api.ts
@@ -14,10 +14,15 @@ export function useCloudflareAPI(apiKey?: string, email?: string) {
       keyEmail: string | undefined = email,
       signal?: AbortSignal,
     ) => {
+      if (api) {
+        await api.verifyToken(signal);
+        return;
+      }
+      if (!key) return Promise.reject(new Error('API key not provided'));
       const client = new ServerClient(key, undefined, keyEmail);
       await client.verifyToken(signal);
     },
-    [apiKey, email],
+    [api, apiKey, email],
   );
 
   const getZones = useCallback(


### PR DESCRIPTION
## Summary
- Delegate token verification to existing API instance when available
- Create fallback client only when no API key is provided
- Include API instance in verifyToken callback dependencies

## Testing
- `npm test test/useCloudflareApi.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a247b80fc48325b2ac4a31ce70ff90