### PR TITLE
Validate stored config before loading

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -58,7 +58,13 @@ export class StorageManager {
     try {
       const stored = this.storage.getItem(STORAGE_KEY);
       if (stored) {
-        this.data = JSON.parse(stored);
+        const parsed = JSON.parse(stored);
+        if (isStorageData(parsed)) {
+          this.data = parsed;
+        } else {
+          this.data = { apiKeys: [] };
+          this.storage.removeItem(STORAGE_KEY);
+        }
       }
     } catch (error) {
       console.error('Failed to load storage data:', error);

--- a/test/storageManager.test.ts
+++ b/test/storageManager.test.ts
@@ -18,6 +18,8 @@ class LocalStorageMock {
   }
 }
 
+const STORAGE_KEY = 'cloudflare-dns-manager';
+
 test('importData accepts valid data', () => {
   const storage = new LocalStorageMock();
   const crypto = new CryptoManager({}, storage);
@@ -53,6 +55,41 @@ test('importData throws on invalid data without modifying existing state', () =>
   assert.throws(() => mgr.importData(JSON.stringify(bad)), /Invalid data format/);
   assert.equal(mgr.getApiKeys().length, 0);
   assert.equal(mgr.getCurrentSession(), undefined);
+});
+
+test('load uses valid stored data', () => {
+  const storage = new LocalStorageMock();
+  const sample = {
+    apiKeys: [
+      {
+        id: '1',
+        label: 'key',
+        encryptedKey: 'enc',
+        salt: 'salt',
+        iv: 'iv',
+        iterations: 1,
+        keyLength: 1,
+        algorithm: 'AES-GCM',
+        createdAt: new Date().toISOString(),
+      },
+    ],
+    currentSession: '1',
+  };
+  storage.setItem(STORAGE_KEY, JSON.stringify(sample));
+  const crypto = new CryptoManager({}, storage);
+  const mgr = new StorageManager(storage, crypto);
+  assert.equal(mgr.getApiKeys().length, 1);
+  assert.equal(mgr.getCurrentSession(), '1');
+});
+
+test('load resets state and clears invalid stored data', () => {
+  const storage = new LocalStorageMock();
+  storage.setItem(STORAGE_KEY, JSON.stringify({ apiKeys: 'nope' }));
+  const crypto = new CryptoManager({}, storage);
+  const mgr = new StorageManager(storage, crypto);
+  assert.equal(mgr.getApiKeys().length, 0);
+  assert.equal(mgr.getCurrentSession(), undefined);
+  assert.equal(storage.getItem(STORAGE_KEY), null);
 });
 
 test('falls back to in-memory storage when localStorage is unavailable', async () => {


### PR DESCRIPTION
## Summary
- Validate parsed storage data with `isStorageData`
- Reset state and clear storage if invalid data is found
- Add unit tests for loading valid and invalid stored data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a253c772b083259bf0b24e1ef65fdf