### PR TITLE
Parse JSON Cloudflare errors in ServerClient

### DIFF
--- a/test/serverClient.test.ts
+++ b/test/serverClient.test.ts
@@ -220,6 +220,21 @@ test('deleteDNSRecord success and error', async () => {
   restore();
 });
 
+test('includes Cloudflare JSON error details', async () => {
+  const client = new ServerClient('key', 'http://example.com');
+  const restore = mockFetch({
+    ok: false,
+    status: 400,
+    statusText: 'Bad Request',
+    headers: { 'content-type': 'application/json' },
+    body: {
+      errors: [{ code: 1001, message: 'bad request' }],
+    },
+  });
+  await assert.rejects(() => client.getZones(), /1001: bad request/);
+  restore();
+});
+
 test('aborts request after timeout', async () => {
   const client = new ServerClient('key', 'http://example.com', undefined, 5);
   let aborted = false;


### PR DESCRIPTION
## Summary
- handle Cloudflare error responses as JSON and surface codes/messages
- add test ensuring JSON error details are included

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a257f10bd08325a696ce2162e79a14