### PR TITLE
Add configurable CORS origin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ npm run server
 ```
 
 By default the API server allows requests from any origin. Set
-`ALLOWED_ORIGIN` to restrict CORS to a specific origin:
+`ALLOWED_ORIGINS` to a comma-separated list to restrict CORS:
 
 ```bash
-ALLOWED_ORIGIN=http://localhost:5173 npm run server
+ALLOWED_ORIGINS=http://localhost:5173,http://example.com npm run server
 ```
 
 Then start the app pointing at the API server:

--- a/server.ts
+++ b/server.ts
@@ -1,12 +1,12 @@
 import express from 'express';
 import { apiRouter } from './src/server/router';
 import { errorHandler } from './src/server/errorHandler';
-import { getEnv, getEnvBool, getEnvNumber } from './src/lib/env';
+import { getEnvBool, getEnvNumber } from './src/lib/env';
+import { getCorsMiddleware } from './src/server/cors';
 
 const app = express();
 const PORT = getEnvNumber('PORT', 'VITE_PORT', 8787);
 const DEBUG = getEnvBool('DEBUG_SERVER', 'VITE_DEBUG_SERVER');
-const ALLOWED_ORIGIN = getEnv('ALLOWED_ORIGIN', 'VITE_ALLOWED_ORIGIN', '*')!;
 
 app.use(express.json());
 if (DEBUG) {
@@ -23,19 +23,7 @@ if (DEBUG) {
     next();
   });
 }
-app.use((req, res, next) => {
-  res.setHeader('Access-Control-Allow-Origin', ALLOWED_ORIGIN);
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    'Content-Type, Authorization, X-Auth-Key, X-Auth-Email'
-  );
-  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
-  if (req.method === 'OPTIONS') {
-    res.sendStatus(204);
-    return;
-  }
-  next();
-});
+app.use(getCorsMiddleware());
 
 app.use(apiRouter);
 

--- a/src/server/cors.ts
+++ b/src/server/cors.ts
@@ -1,0 +1,40 @@
+import type { Request, Response, NextFunction } from 'express';
+import { getEnv } from '../lib/env.ts';
+
+export function getCorsMiddleware() {
+  const env = getEnv('ALLOWED_ORIGINS', 'VITE_ALLOWED_ORIGINS', '*')!;
+  const allowed = new Set(
+    env
+      .split(',')
+      .map((o) => o.trim())
+      .filter((o) => o.length > 0),
+  );
+
+  return function cors(req: Request, res: Response, next: NextFunction) {
+    const origin = req.headers.origin as string | undefined;
+    if (origin && (allowed.has('*') || allowed.has(origin))) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+    } else if (origin) {
+      res.status(403).json({ error: 'Origin not allowed' });
+      return;
+    }
+
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization, X-Auth-Key, X-Auth-Email',
+    );
+    res.setHeader(
+      'Access-Control-Allow-Methods',
+      'GET,POST,PUT,DELETE,OPTIONS',
+    );
+
+    if (req.method === 'OPTIONS') {
+      res.sendStatus(204);
+      return;
+    }
+
+    next();
+  };
+}
+
+export type CorsMiddleware = ReturnType<typeof getCorsMiddleware>;

--- a/test/apiErrorHandler.test.ts
+++ b/test/apiErrorHandler.test.ts
@@ -5,6 +5,7 @@ import express from 'express';
 import { apiRouter } from '../src/server/router.ts';
 import { errorHandler } from '../src/server/errorHandler.ts';
 import { asyncHandler } from '../src/lib/async-handler.ts';
+import { getCorsMiddleware } from '../src/server/cors.ts';
 
 import type { AddressInfo } from 'node:net';
 
@@ -50,5 +51,50 @@ test('generic errors return 500', async () => {
     assert.ok(/boom/.test(data.error));
   } finally {
     server.close();
+  }
+});
+
+test('allowed origin sets CORS header', async () => {
+  process.env.ALLOWED_ORIGINS = 'http://allowed.test';
+  const app = express();
+  app.use(getCorsMiddleware());
+  app.get('/api/test', (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  const server = app.listen(0);
+  const { port } = server.address() as AddressInfo;
+  try {
+    const res = await fetch(`http://localhost:${port}/api/test`, {
+      headers: { Origin: 'http://allowed.test' },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('access-control-allow-origin'), 'http://allowed.test');
+  } finally {
+    server.close();
+    delete process.env.ALLOWED_ORIGINS;
+  }
+});
+
+test('disallowed origin returns 403', async () => {
+  process.env.ALLOWED_ORIGINS = 'http://allowed.test';
+  const app = express();
+  app.use(getCorsMiddleware());
+  app.get('/api/test', (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  const server = app.listen(0);
+  const { port } = server.address() as AddressInfo;
+  try {
+    const res = await fetch(`http://localhost:${port}/api/test`, {
+      headers: { Origin: 'http://evil.test' },
+    });
+    assert.equal(res.status, 403);
+    const data = await res.json();
+    assert.ok(/Origin not allowed/.test(data.error));
+  } finally {
+    server.close();
+    delete process.env.ALLOWED_ORIGINS;
   }
 });


### PR DESCRIPTION
## Summary
- make CORS configurable via `ALLOWED_ORIGINS`
- document `ALLOWED_ORIGINS` env variable
- test allowed and disallowed origins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a257e359688325b765683f4ea37bca