### PR TITLE
Validate DNS record type and priority

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
+import { RECORD_TYPES } from '../types/dns';
 
 export const dnsRecordSchema = z.object({
-  type: z.string(),
+  type: z.enum(RECORD_TYPES),
   name: z.string(),
   content: z.string(),
   ttl: z.number().int().optional(),
+  priority: z.number().int().optional(),
   proxied: z.boolean().optional(),
 });
 


### PR DESCRIPTION
## Summary
- restrict DNS record type to known Cloudflare record types
- validate DNS record priority as optional integer field

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a46be50c888325bfd14025bfb484c1