### PR TITLE
Send wildcard CORS origin and vary by origin

### DIFF
--- a/src/server/cors.ts
+++ b/src/server/cors.ts
@@ -12,8 +12,12 @@ export function getCorsMiddleware() {
 
   return function cors(req: Request, res: Response, next: NextFunction) {
     const origin = req.headers.origin as string | undefined;
-    if (origin && (allowed.has('*') || allowed.has(origin))) {
+    if (allowed.has('*')) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Vary', 'Origin');
+    } else if (origin && allowed.has(origin)) {
       res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Vary', 'Origin');
     } else if (origin) {
       res.status(403).json({ error: 'Origin not allowed' });
       return;


### PR DESCRIPTION
## Summary
- return `*` for `Access-Control-Allow-Origin` when all origins are allowed
- add `Vary: Origin` header after setting the CORS origin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46bef37248325b1a46a26a8742706