### PR TITLE
refactor: clarify unused error handler param

### DIFF
--- a/src/server/errorHandler.ts
+++ b/src/server/errorHandler.ts
@@ -7,11 +7,11 @@ export function errorHandler(
   err: unknown,
   _req: Request,
   res: Response,
-  next: NextFunction,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _next: NextFunction,
 ) {
   if (DEBUG) console.error(err);
   const status = (err as { status?: number }).status ?? 500;
   res.status(status).json({ error: (err as Error).message });
-  void next;
 }
 


### PR DESCRIPTION
## Summary
- rename Express error handler `next` arg to `_next`
- drop redundant `void next` line and silence lint warning

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6146e178c8325a10c4f9e56f9d7c5