### PR TITLE
refactor: centralize CORS origin handling

### DIFF
--- a/src/server/cors.ts
+++ b/src/server/cors.ts
@@ -12,15 +12,20 @@ export function getCorsMiddleware() {
 
   return function cors(req: Request, res: Response, next: NextFunction) {
     const origin = req.headers.origin as string | undefined;
+    let allowedOrigin: string | undefined;
+
     if (allowed.has('*')) {
-      res.setHeader('Access-Control-Allow-Origin', '*');
-      res.setHeader('Vary', 'Origin');
+      allowedOrigin = '*';
     } else if (origin && allowed.has(origin)) {
-      res.setHeader('Access-Control-Allow-Origin', origin);
-      res.setHeader('Vary', 'Origin');
+      allowedOrigin = origin;
     } else if (origin) {
       res.status(403).json({ error: 'Origin not allowed' });
       return;
+    }
+
+    if (allowedOrigin) {
+      res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
+      res.setHeader('Vary', 'Origin');
     }
 
     res.setHeader(


### PR DESCRIPTION
## Summary
- compute CORS origin once and set `Vary: Origin` after sending `Access-Control-Allow-Origin`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a61463807883259c95c3e16e927299