### PR TITLE
Use Number.parseInt with NaN guards for record fields

### DIFF
--- a/src/components/auth/EncryptionSettingsDialog.tsx
+++ b/src/components/auth/EncryptionSettingsDialog.tsx
@@ -43,9 +43,13 @@ export function EncryptionSettingsDialog({ open, onOpenChange, settings, onSetti
               id="iterations"
               type="number"
               value={settings.iterations}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                onSettingsChange({ ...settings, iterations: parseInt(e.target.value) || 100000 })
-              }
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                const n = Number.parseInt(e.target.value, 10);
+                onSettingsChange({
+                  ...settings,
+                  iterations: Number.isNaN(n) ? 100000 : n
+                });
+              }}
             />
           </div>
           <div className="space-y-2">

--- a/src/components/dns/AddRecordDialog.tsx
+++ b/src/components/dns/AddRecordDialog.tsx
@@ -65,12 +65,13 @@ export function AddRecordDialog({ open, onOpenChange, record, onRecordChange, on
               <Input
                 type="number"
                 value={record.ttl}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  const n = Number.parseInt(e.target.value, 10);
                   onRecordChange({
                     ...record,
-                    ttl: parseInt(e.target.value) || 300
-                  })
-                }
+                    ttl: Number.isNaN(n) ? 300 : n
+                  });
+                }}
               />
             </div>
           </div>
@@ -102,11 +103,13 @@ export function AddRecordDialog({ open, onOpenChange, record, onRecordChange, on
               <Input
                 type="number"
                 value={record.priority || ''}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  const n = Number.parseInt(e.target.value, 10);
                   onRecordChange({
                     ...record,
-                    priority: parseInt(e.target.value) || undefined
-                  })}
+                    priority: Number.isNaN(n) ? undefined : n
+                  });
+                }}
               />
             </div>
           )}

--- a/src/components/dns/RecordRow.tsx
+++ b/src/components/dns/RecordRow.tsx
@@ -73,24 +73,26 @@ export function RecordRow({ record, isEditing, onEdit, onSave, onCancel, onDelet
             <Input
               type="number"
               value={editedRecord.ttl}
-              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                const n = Number.parseInt(e.target.value, 10);
                 setEditedRecord({
                   ...editedRecord,
-                  ttl: parseInt(e.target.value) || 300,
-                })
-              }
+                  ttl: Number.isNaN(n) ? 300 : n,
+                });
+              }}
               className="h-8"
             />
             {editedRecord.type === 'MX' && (
               <Input
                 type="number"
                 value={editedRecord.priority ?? ''}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  const n = Number.parseInt(e.target.value, 10);
                   setEditedRecord({
                     ...editedRecord,
-                    priority: e.target.value ? parseInt(e.target.value) : undefined,
-                  })
-                }
+                    priority: Number.isNaN(n) ? undefined : n,
+                  });
+                }}
                 className="h-8"
               />
             )}


### PR DESCRIPTION
## Summary
- Switch DNS record TTL and priority parsing to `Number.parseInt` and guard with `Number.isNaN`
- Handle MX priority parsing so value `0` is preserved rather than dropped
- Parse PBKDF2 iterations with `Number.parseInt` and retain default only when input is not a number

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a725cc827483258c161f24232a514a