### PR TITLE
Quote CSV fields and escape quotes

### DIFF
--- a/src/components/dns/dns-manager.tsx
+++ b/src/components/dns/dns-manager.tsx
@@ -178,14 +178,24 @@ export function DNSManager({ apiKey, email, onLogout }: DNSManagerProps) {
         break;
       }
       case 'csv': {
-        const headers = 'Type,Name,Content,TTL,Priority,Proxied\n';
+        const headers = ['Type', 'Name', 'Content', 'TTL', 'Priority', 'Proxied'];
+        const escapeCSV = (value: unknown) =>
+          `"${String(value ?? '').replace(/"/g, '""')}"`;
         const rows = records
-          .map(
-            (r: DNSRecord) =>
-              `${r.type},${r.name},${r.content},${r.ttl},${r.priority || ''},${r.proxied || false}`
+          .map((r: DNSRecord) =>
+            [
+              r.type,
+              r.name,
+              r.content,
+              r.ttl,
+              r.priority ?? '',
+              r.proxied ?? false,
+            ]
+              .map(escapeCSV)
+              .join(',')
           )
           .join('\n');
-        content = headers + rows;
+        content = headers.map(escapeCSV).join(',') + '\n' + rows;
         filename = `${selectedZone}-records.csv`;
         mimeType = 'text/csv';
         break;


### PR DESCRIPTION
## Summary
- Ensure DNS CSV exports wrap every field in quotes
- Escape embedded quotes to prevent malformed CSV

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7412f0a7c832599242a782d2b4ad6