### PR TITLE
feat: add TTL presets and select-based TTL input

### DIFF
--- a/src/components/dns/AddRecordDialog.tsx
+++ b/src/components/dns/AddRecordDialog.tsx
@@ -6,7 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import type { DNSRecord, RecordType } from '@/types/dns';
-import { RECORD_TYPES } from '@/types/dns';
+import { RECORD_TYPES, TTL_PRESETS } from '@/types/dns';
 import { Plus } from 'lucide-react';
 
 export interface AddRecordDialogProps {
@@ -19,6 +19,10 @@ export interface AddRecordDialogProps {
 }
 
 export function AddRecordDialog({ open, onOpenChange, record, onRecordChange, onAdd, zoneName }: AddRecordDialogProps) {
+  const ttlValue = record.ttl === 1 ? 'auto' : record.ttl;
+  const isCustomTTL =
+    ttlValue !== undefined && !TTL_PRESETS.includes(ttlValue as any);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
@@ -62,17 +66,44 @@ export function AddRecordDialog({ open, onOpenChange, record, onRecordChange, on
             </div>
             <div className="space-y-2">
               <Label>TTL</Label>
-              <Input
-                type="number"
-                value={record.ttl}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                  const n = Number.parseInt(e.target.value, 10);
-                  onRecordChange({
-                    ...record,
-                    ttl: Number.isNaN(n) ? 300 : n
-                  });
+              <Select
+                value={isCustomTTL ? 'custom' : String(ttlValue)}
+                onValueChange={(value: string) => {
+                  if (value === 'custom') {
+                    onRecordChange({ ...record, ttl: 300 });
+                  } else {
+                    onRecordChange({
+                      ...record,
+                      ttl: value === 'auto' ? 'auto' : Number(value)
+                    });
+                  }
                 }}
-              />
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TTL_PRESETS.map((ttl) => (
+                    <SelectItem key={ttl} value={String(ttl)}>
+                      {ttl === 'auto' ? 'Auto' : ttl}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="custom">Custom</SelectItem>
+                </SelectContent>
+              </Select>
+              {isCustomTTL && (
+                <Input
+                  type="number"
+                  value={typeof record.ttl === 'number' ? record.ttl : ''}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    const n = Number.parseInt(e.target.value, 10);
+                    onRecordChange({
+                      ...record,
+                      ttl: Number.isNaN(n) ? 300 : n
+                    });
+                  }}
+                />
+              )}
             </div>
           </div>
           <div className="space-y-2">

--- a/src/lib/cloudflare.ts
+++ b/src/lib/cloudflare.ts
@@ -53,7 +53,7 @@ export class CloudflareAPI {
       type: record.type,
       name: record.name,
       content: record.content,
-      ttl: record.ttl,
+      ttl: record.ttl === 'auto' ? 1 : record.ttl,
       priority: record.priority,
       proxied: record.proxied,
     };

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -5,7 +5,7 @@ export const dnsRecordSchema = z.object({
   type: z.enum(RECORD_TYPES),
   name: z.string(),
   content: z.string(),
-  ttl: z.number().int().optional(),
+  ttl: z.union([z.literal('auto'), z.number().int()]).optional(),
   priority: z.number().int().optional(),
   proxied: z.boolean().optional(),
 });

--- a/src/types/dns.ts
+++ b/src/types/dns.ts
@@ -3,7 +3,7 @@ export interface DNSRecord {
   type: string;
   name: string;
   content: string;
-  ttl: number;
+  ttl: number | 'auto';
   priority?: number;
   proxied?: boolean;
   zone_id: string;
@@ -65,3 +65,6 @@ export const RECORD_TYPES: RecordType[] = [
   'PTR',
   'CAA'
 ];
+
+export const TTL_PRESETS = ['auto', 300, 900, 3600, 86400] as const;
+export type TTLValue = typeof TTL_PRESETS[number];


### PR DESCRIPTION
## Summary
- add shared TTL presets and allow `auto` TTL option
- replace numeric TTL fields with dropdown presets and optional custom value
- map `Auto` TTL to Cloudflare's 1 value when sending to API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aca8cedf1483259e4378bd81a24ca4