### PR TITLE
Add basic rate limiting to API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ Run the app with the custom base applied:
 VITE_SERVER_API_BASE=http://localhost:8787/api npm run dev
 ```
 
+### Rate limiting
+
+The API server enforces a simple rate limit. Adjust the limits with:
+
+```bash
+RATE_LIMIT_WINDOW=60000 RATE_LIMIT_MAX=100 npm run server
+```
+
+`RATE_LIMIT_WINDOW` defines the window size in milliseconds and `RATE_LIMIT_MAX`
+sets the number of requests allowed per window for each IP. The defaults are
+60,000 ms and 100 requests.
+
 ## Building for production
 
 Create an optimized build and preview it locally:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "cloudflare": "^4.5.0",
         "clsx": "^2.1.1",
         "express": "^4.19.2",
+        "express-rate-limit": "^6.11.2",
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -4196,6 +4197,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.11.2.tgz",
+      "integrity": "sha512-a7uwwfNTh1U60ssiIkuLFWHt4hAC5yxlLGU2VP0X4YNlyEDZAqF4tK3GD3NSitVBrCQmQ0++0uOyFOgC2y4DDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
       }
     },
     "node_modules/express/node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cloudflare": "^4.5.0",
     "clsx": "^2.1.1",
     "express": "^4.19.2",
+    "express-rate-limit": "^6.11.2",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/server.ts
+++ b/server.ts
@@ -1,12 +1,25 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import { apiRouter } from './src/server/router';
 import { errorHandler } from './src/server/errorHandler';
-import { getEnvBool, getEnvNumber } from './src/lib/env';
+import {
+  getEnvBool,
+  getEnvNumber,
+  RATE_LIMIT_WINDOW,
+  RATE_LIMIT_MAX,
+} from './src/lib/env';
 import { getCorsMiddleware } from './src/server/cors';
 
 const app = express();
 const PORT = getEnvNumber('PORT', 'VITE_PORT', 8787);
 const DEBUG = getEnvBool('DEBUG_SERVER', 'VITE_DEBUG_SERVER');
+
+const rateLimiter = rateLimit({
+  windowMs: RATE_LIMIT_WINDOW,
+  max: RATE_LIMIT_MAX,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 app.use(express.json());
 if (DEBUG) {
@@ -24,6 +37,8 @@ if (DEBUG) {
   });
 }
 app.use(getCorsMiddleware());
+
+app.use(rateLimiter);
 
 app.use(apiRouter);
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -33,3 +33,18 @@ export function getEnvNumber(
   const parsed = Number(val);
   return Number.isNaN(parsed) ? defaultValue : parsed;
 }
+
+/**
+ * Rate limiting configuration (defaults: 60s window, 100 requests)
+ */
+export const RATE_LIMIT_WINDOW = getEnvNumber(
+  'RATE_LIMIT_WINDOW',
+  'VITE_RATE_LIMIT_WINDOW',
+  60_000,
+);
+
+export const RATE_LIMIT_MAX = getEnvNumber(
+  'RATE_LIMIT_MAX',
+  'VITE_RATE_LIMIT_MAX',
+  100,
+);


### PR DESCRIPTION
## Summary
- add express-rate-limit middleware for global request throttling
- make rate limiter configurable via RATE_LIMIT_WINDOW and RATE_LIMIT_MAX env vars
- document rate limiting options in README

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68acad40b37883258b35f0e35e395070