### PR TITLE
feat: support importing DNS records from CSV and BIND

### DIFF
--- a/src/components/dns/import-export-dialog.tsx
+++ b/src/components/dns/import-export-dialog.tsx
@@ -9,7 +9,9 @@ interface ImportExportDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   importData: string;
+  importFormat: 'json' | 'csv' | 'bind';
   onImportDataChange: (data: string) => void;
+  onImportFormatChange: (format: 'json' | 'csv' | 'bind') => void;
   onImport: () => void;
   onExport: (format: 'json' | 'csv' | 'bind') => void;
 }
@@ -18,7 +20,9 @@ export function ImportExportDialog({
   open,
   onOpenChange,
   importData,
+  importFormat,
   onImportDataChange,
+  onImportFormatChange,
   onImport,
   onExport
 }: ImportExportDialogProps) {
@@ -35,17 +39,30 @@ export function ImportExportDialog({
           <DialogHeader>
             <DialogTitle>Import DNS Records</DialogTitle>
             <DialogDescription>
-              Import DNS records from JSON format
+              Import DNS records from JSON, CSV, or BIND zone formats
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div className="space-y-2">
-              <Label>JSON Data</Label>
+              <Label>Format</Label>
+              <Select value={importFormat} onValueChange={onImportFormatChange}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select format" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="json">JSON</SelectItem>
+                  <SelectItem value="csv">CSV</SelectItem>
+                  <SelectItem value="bind">BIND</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>{importFormat.toUpperCase()} Data</Label>
               <textarea
                 className="w-full h-32 p-2 border rounded-md bg-background"
                 value={importData}
                 onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onImportDataChange(e.target.value)}
-                placeholder="Paste your JSON data here..."
+                placeholder={`Paste your ${importFormat.toUpperCase()} data here...`}
               />
             </div>
             <Button onClick={onImport} className="w-full">

--- a/src/lib/dns-parsers.ts
+++ b/src/lib/dns-parsers.ts
@@ -1,0 +1,96 @@
+import type { DNSRecord } from '@/types/dns';
+
+function parseCSVLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  result.push(current);
+  return result.map((v) => v.trim());
+}
+
+export function parseCSVRecords(text: string): Partial<DNSRecord>[] {
+  const lines = text.trim().split(/\r?\n/).filter(Boolean);
+  if (lines.length === 0) return [];
+
+  const headers = parseCSVLine(lines[0]).map((h) => h.toLowerCase());
+  const idx = {
+    type: headers.indexOf('type'),
+    name: headers.indexOf('name'),
+    content: headers.indexOf('content'),
+    ttl: headers.indexOf('ttl'),
+    priority: headers.indexOf('priority'),
+    proxied: headers.indexOf('proxied'),
+  };
+
+  const records: Partial<DNSRecord>[] = [];
+  for (const line of lines.slice(1)) {
+    const values = parseCSVLine(line);
+    if (!values.length) continue;
+    const record: Partial<DNSRecord> = {
+      type: idx.type >= 0 ? values[idx.type] : undefined,
+      name: idx.name >= 0 ? values[idx.name] : undefined,
+      content: idx.content >= 0 ? values[idx.content] : undefined,
+    };
+
+    const ttlVal = idx.ttl >= 0 ? values[idx.ttl] : undefined;
+    if (ttlVal) record.ttl = ttlVal === 'auto' ? 'auto' : Number(ttlVal);
+
+    const prVal = idx.priority >= 0 ? values[idx.priority] : undefined;
+    if (prVal) record.priority = Number(prVal);
+
+    const proxiedVal = idx.proxied >= 0 ? values[idx.proxied] : undefined;
+    if (proxiedVal) record.proxied = /^(true|1)$/i.test(proxiedVal);
+
+    records.push(record);
+  }
+
+  return records;
+}
+
+export function parseBINDZone(text: string): Partial<DNSRecord>[] {
+  const lines = text.trim().split(/\r?\n/);
+  const records: Partial<DNSRecord>[] = [];
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith(';')) continue;
+    const noComment = line.split(';')[0].trim();
+    const parts = noComment.split(/\s+/);
+    if (parts.length < 4) continue;
+    const [name, ttlStr, , type, ...rest] = parts;
+    const ttl = Number(ttlStr) || 300;
+    let priority: number | undefined;
+    let contentParts = rest;
+    if (type.toUpperCase() === 'MX' && rest.length >= 2) {
+      priority = Number(rest[0]);
+      contentParts = rest.slice(1);
+    }
+    const record: Partial<DNSRecord> = {
+      name,
+      ttl,
+      type,
+      content: contentParts.join(' '),
+    };
+    if (priority !== undefined) record.priority = priority;
+    records.push(record);
+  }
+
+  return records;
+}
+


### PR DESCRIPTION
## Summary
- allow choosing JSON, CSV or BIND as import format
- parse CSV and BIND zone file records via new utility functions
- validate and merge imported records after format-specific parsing

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in AddRecordDialog.tsx and RecordRow.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ace34f1b048325abc52f3905c686be