### PR TITLE
feat: persist last selected zone

### DIFF
--- a/src/components/dns/dns-manager.tsx
+++ b/src/components/dns/dns-manager.tsx
@@ -92,12 +92,25 @@ export function DNSManager({ apiKey, email, onLogout }: DNSManagerProps) {
   }, [loadZones]);
 
   useEffect(() => {
+    const last = storageManager.getLastZone();
+    if (last) {
+      setSelectedZone(last);
+    }
+  }, []);
+
+  useEffect(() => {
     if (selectedZone) {
       const controller = new AbortController();
       loadRecords(controller.signal);
       return () => controller.abort();
     }
   }, [selectedZone, loadRecords]);
+
+  useEffect(() => {
+    if (selectedZone) {
+      storageManager.setLastZone(selectedZone);
+    }
+  }, [selectedZone]);
 
   const handleAddRecord = async () => {
     if (!selectedZone || !newRecord.type || !newRecord.name || !newRecord.content) {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -12,16 +12,24 @@ const STORAGE_KEY = 'cloudflare-dns-manager';
 interface StorageData {
   apiKeys: ApiKey[];
   currentSession?: string;
+  lastZone?: string;
 }
 
 export function isStorageData(value: unknown): value is StorageData {
   if (!value || typeof value !== 'object') return false;
-  const obj = value as { apiKeys?: unknown; currentSession?: unknown };
+  const obj = value as {
+    apiKeys?: unknown;
+    currentSession?: unknown;
+    lastZone?: unknown;
+  };
   if (!Array.isArray(obj.apiKeys)) return false;
   if (
     obj.currentSession !== undefined &&
     typeof obj.currentSession !== 'string'
   ) {
+    return false;
+  }
+  if (obj.lastZone !== undefined && typeof obj.lastZone !== 'string') {
     return false;
   }
   return obj.apiKeys.every(k => {
@@ -153,7 +161,17 @@ export class StorageManager {
 
   clearSession(): void {
     this.data.currentSession = undefined;
+    this.data.lastZone = undefined;
     this.save();
+  }
+
+  setLastZone(zoneId: string): void {
+    this.data.lastZone = zoneId;
+    this.save();
+  }
+
+  getLastZone(): string | undefined {
+    return this.data.lastZone;
   }
 
   exportData(): string {

--- a/test/storageManager.test.ts
+++ b/test/storageManager.test.ts
@@ -101,3 +101,13 @@ test('falls back to in-memory storage when localStorage is unavailable', async (
   const mgr2 = new StorageManager(undefined, crypto);
   assert.equal(mgr2.getApiKeys().length, 0);
 });
+
+test('stores and clears last selected zone', () => {
+  const storage = new LocalStorageMock();
+  const crypto = new CryptoManager({}, storage);
+  const mgr = new StorageManager(storage, crypto);
+  mgr.setLastZone('zone-1');
+  assert.equal(mgr.getLastZone(), 'zone-1');
+  mgr.clearSession();
+  assert.equal(mgr.getLastZone(), undefined);
+});


### PR DESCRIPTION
## Summary
- add lastZone to StorageManager with accessors and session clearing
- persist selected zone in DNSManager using storage
- test storage for persisting and clearing last zone

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in AddRecordDialog.tsx, RecordRow.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68adfc095eb08325bc58f6153a54b331